### PR TITLE
Update runner files to download herd at startup

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -14,11 +14,10 @@ RUN ARCH=$(echo "$TARGETARCH" | sed 's/amd64/x64/' | sed 's/arm64/arm64/') \
     && curl -sL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz" \
     | tar xz
 
-# Herd CLI (will switch to binary download when releases are available)
-RUN apt-get update && apt-get install -y golang-go \
-    && go install github.com/herd-os/herd/cmd/herd@latest \
-    && cp $(go env GOPATH)/bin/herd /usr/local/bin/herd \
-    && apt-get purge -y golang-go && apt-get autoremove -y
+# Herd CLI is installed at startup by entrypoint.sh
+# Set HERD_VERSION in .env to pin a version, otherwise latest is used.
+RUN mkdir -p /opt/herd/bin
+ENV PATH="/opt/herd/bin:${PATH}"
 
 # Agent CLI
 RUN npm install -g @anthropic-ai/claude-code
@@ -29,7 +28,7 @@ RUN npm install -g @anthropic-ai/claude-code
 
 # Runner must not run as root
 RUN useradd -m -d /home/runner runner \
-    && chown -R runner:runner /runner
+    && chown -R runner:runner /runner /opt/herd
 
 WORKDIR /runner
 COPY entrypoint.sh .

--- a/docker-compose.herd.yml
+++ b/docker-compose.herd.yml
@@ -15,5 +15,6 @@ services:
       - RUNNER_LABELS=herd-worker
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - HERD_VERSION=${HERD_VERSION:-}
     deploy:
       replicas: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,18 @@ get_token() {
     | jq -r .token
 }
 
+# Install or update herd CLI
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+if [ -n "${HERD_VERSION:-}" ] && [ "$HERD_VERSION" != "latest" ]; then
+  HERD_URL="https://github.com/Herd-OS/herd/releases/download/${HERD_VERSION}/herd-linux-${ARCH}"
+else
+  HERD_URL="https://github.com/Herd-OS/herd/releases/latest/download/herd-linux-${ARCH}"
+fi
+echo "Installing herd from ${HERD_URL}..."
+curl -fsSL "$HERD_URL" -o /opt/herd/bin/herd
+chmod +x /opt/herd/bin/herd
+echo "Installed herd $(herd --version 2>/dev/null || echo 'unknown')"
+
 REPO_OWNER=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\1|')
 REPO_NAME=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\2|')
 


### PR DESCRIPTION
Updates Dockerfile, entrypoint, and docker-compose to download herd binary at container startup instead of baking it in at build time.