### PR TITLE
Update HerdOS to v0.2.0-rc.5

### DIFF
--- a/.env.herd.example
+++ b/.env.herd.example
@@ -18,3 +18,6 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Herd version for runner containers (optional — defaults to latest)
 # Set this to pin a specific version, e.g.:
 # HERD_VERSION=v0.1.0-rc.2
+
+# Enable agent debug logging (optional — dumps Claude Code debug logs on failure)
+# HERD_AGENT_DEBUG=true

--- a/Dockerfile.herd_runner_base
+++ b/Dockerfile.herd_runner_base
@@ -3,9 +3,11 @@ FROM ubuntu:24.04
 ARG RUNNER_VERSION=2.332.0
 ARG TARGETARCH
 
-# Dependencies
+# Dependencies (Node 22 LTS required by Claude Code, libicu for GitHub Actions runner)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl jq ca-certificates git gh nodejs npm \
+    curl jq ca-certificates git gh libicu-dev \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub Actions runner

--- a/docker-compose.herd.yml
+++ b/docker-compose.herd.yml
@@ -27,5 +27,6 @@ services:
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - HERD_VERSION=${HERD_VERSION:-}
+      - HERD_AGENT_DEBUG=${HERD_AGENT_DEBUG:-}
     deploy:
       replicas: 3

--- a/entrypoint.herd.sh
+++ b/entrypoint.herd.sh
@@ -39,7 +39,7 @@ REPO_NAME=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\2|')
 
 # Remove stale config from previous run (ephemeral runners leave config behind on restart)
 if [ -f .runner ]; then
-  ./config.sh remove --token "$(get_token)" || true
+  ./config.sh remove --token "$(get_token)" || rm -f .runner .credentials .credentials_rsaparams
 fi
 
 ./config.sh \


### PR DESCRIPTION
Updates HerdOS workflows and runner infrastructure to v0.2.0-rc.5.

Created by `herd init`.