### PR TITLE
Sync docs from herd@99cb696

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -66,10 +66,10 @@ Controls how aggressively the agent reviewer flags issues:
 
 Findings are classified by severity:
 - **HIGH**: Bugs, security vulnerabilities, race conditions, missing critical error handling — triggers fix workers
-- **MEDIUM**: Missing edge cases, suboptimal error handling — informational only
+- **MEDIUM**: Missing edge cases, suboptimal error handling — triggers fix workers
 - **LOW**: Style preferences, naming suggestions — informational only
 
-Only HIGH severity findings create fix issues and dispatch workers. MEDIUM and LOW findings are listed in the PR comment for reference.
+HIGH and MEDIUM severity findings create fix issues and dispatch workers. LOW findings are listed in the PR comment for reference.
 
 ## Managing Configuration
 

--- a/src/content/docs/design/architecture.md
+++ b/src/content/docs/design/architecture.md
@@ -83,7 +83,7 @@ The entire flow after `herd plan` is self-driving. The Planner dispatches Tier 0
 
 ### Review and Fix Details
 
-Agent review collects `/herd fix` comments from the batch PR before reviewing, so user-requested fixes are not flagged as violations. It then classifies findings by severity (HIGH, MEDIUM, LOW). Only HIGH severity findings — bugs, security issues, race conditions — trigger fix workers. MEDIUM and LOW findings are included in the PR comment for reference but do not block merge or create fix issues.
+Agent review collects `/herd fix` comments from the batch PR before reviewing, so user-requested fixes are not flagged as violations. It then classifies findings by severity (HIGH, MEDIUM, LOW). HIGH and MEDIUM severity findings trigger fix workers. LOW findings are included in the PR comment for reference but do not block merge or create fix issues.
 
 Each review cycle creates at most one batch fix issue containing all HIGH findings, rather than one issue per finding. The agent submits a Request Changes review to block merge while fix cycles are active. When the review passes, the agent approves and posts a batch summary with statistics (files reviewed, findings by severity, fix cycles used).
 

--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -269,7 +269,7 @@ Review findings are classified by severity:
 | Severity | Examples | Action |
 |----------|----------|--------|
 | HIGH | Bugs, security vulnerabilities, race conditions, missing critical error handling | Creates fix issues, dispatches workers |
-| MEDIUM | Missing edge cases, suboptimal error handling | Listed in PR comment, no fix workers |
+| MEDIUM | Missing edge cases, suboptimal error handling | Creates fix issues, dispatches workers |
 | LOW | Style preferences, naming suggestions | Listed in PR comment, no fix workers |
 
 The `review_strictness` setting (standard/strict/lenient) controls which issues the agent flags. See [Configuration](../configuration.md#review-strictness) for details.


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`99cb696`](https://github.com/Herd-OS/herd/commit/99cb6966925c3f5fcf8e56d29f267cecf62c1e54).