### PR TITLE
Sync docs from herd@59bdd1e

### DIFF
--- a/src/content/docs/design/architecture.md
+++ b/src/content/docs/design/architecture.md
@@ -91,6 +91,8 @@ Workers run pre-push validation before pushing changes. For Go repositories, thi
 
 When the Integrator processes commands (Consolidate, Advance, AdvanceByBatch, CheckCI), it skips batches whose milestones are already closed, avoiding redundant work on completed batches.
 
+Opening a batch PR is idempotent: if two concurrent integrator runs both attempt to create the PR, the second detects the existing one (via listing or by handling a 422 race) and returns the existing PR number.
+
 ### Worker, Consolidate, PR flow
 
 ```

--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -230,6 +230,8 @@ Rebase batch branch onto latest main
 Open single PR: batch branch -> main
 ```
 
+Opening the batch PR is idempotent: if concurrent advance-on-close triggers race, the second call detects the existing PR (via listing or by handling a 422 "already exists" error) and returns its number instead of failing.
+
 ### Run-to-Branch Resolution
 
 Given a completed workflow run ID, the Integrator resolves the worker branch:


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`59bdd1e`](https://github.com/Herd-OS/herd/commit/59bdd1e85fe1a0576c0ba741529b5ecbe78ca1f0).