### PR TITLE
[herd] Hide mermaid blocks until rendered with loading spinner (1 tasks)

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -169,6 +169,7 @@ const { title, currentSlug } = Astro.props;
       document.querySelectorAll('.mermaid').forEach((div) => div.remove());
       originals.forEach(({ pre, parent, next }) => {
         parent.insertBefore(pre, next);
+        (pre as HTMLElement).removeAttribute('data-language');
         (pre as HTMLElement).style.visibility = 'visible';
         (pre as HTMLElement).style.height = 'auto';
         (pre as HTMLElement).style.overflow = 'visible';


### PR DESCRIPTION
## Summary

Batch **Hide mermaid blocks until rendered with loading spinner** — 1 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #84 | CSS-hide mermaid code blocks and show loading spinner until rendered | 0 | done |

## Worker branches

- `herd/worker/84-css-hide-mermaid-code-blocks-and-show-loading-spin`
