### PR TITLE
[herd] Fix Unsupported markdown list in Mermaid diagrams (1 tasks)

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -156,7 +156,9 @@ const { title, currentSlug } = Astro.props;
         if (!pre) return;
         const div = document.createElement('div');
         div.className = 'mermaid';
-        div.textContent = codeEl.textContent || '';
+        const raw = codeEl.textContent || '';
+        // Escape '1. ', '2. ' etc. so Mermaid's markdown parser doesn't treat them as list items
+        div.textContent = raw.replace(/(\d+)\. /g, '$1\\. ');
         pre.replaceWith(div);
       });
 


### PR DESCRIPTION
## Summary

Batch **Fix Unsupported markdown list in Mermaid diagrams** — 1 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #87 | Escape ordered-list patterns in Mermaid source before rendering | 0 | done |

## Worker branches

- `herd/worker/87-escape-ordered-list-patterns-in-mermaid-source-bef`
