### PR TITLE
Sync docs from herd@6e43d56

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -104,6 +104,17 @@ Workers also post a report on the no-op path (when no changes are needed). The
 no-op report includes a "No changes were needed" message with the agent output
 in a collapsible details block.
 
+### Image Preprocessing
+
+Before invoking the agent, the worker scans the issue body for GitHub-hosted
+attachment images (URLs matching `github.com/user-attachments/assets/*`,
+`github.com/<owner>/<repo>/assets/*`, and
+`private-user-images.githubusercontent.com/*`). Matched images are downloaded to
+`.herd/tmp/images/` and the markdown URLs are replaced with local file paths so
+the agent can view them directly. External image URLs are left unchanged for the
+agent to handle. Downloading is best-effort -- if the HTTP client is unavailable
+or a download fails, the original URL is preserved.
+
 ### Concurrency
 
 Multiple workers run simultaneously on separate branches. Concurrency is bounded

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -236,6 +236,8 @@ When you post a command, HerdOS reacts with 👀 to acknowledge it, executes the
 | `/herd review <focus area>` | Batch PR | Same as above, with extra review instructions |
 | `/herd fix <description>` | Batch PR | Creates a fix issue and dispatches a worker. The full PR comment thread is included in the fix issue so the worker has context of prior iterations. The reviewer automatically recognizes these fixes and will not flag them as acceptance criteria violations. |
 
+**Image support:** When you attach screenshots to `/herd fix` comments, workers automatically download GitHub-hosted attachment images and can view them directly. This is useful for UI bug fixes -- paste a screenshot of the problem or the desired result, and the worker will see it. Only GitHub attachment URLs are downloaded; external image URLs are left as-is for the agent to handle.
+
 ### Examples
 
 ```


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`6e43d56`](https://github.com/Herd-OS/herd/commit/6e43d56b23d0ef91a416a0d0e01bb08b048b2a44).