### PR TITLE
Sync docs from herd@fe9f786

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -104,6 +104,17 @@ Workers also post a report on the no-op path (when no changes are needed). The
 no-op report includes a "No changes were needed" message with the agent output
 in a collapsible details block.
 
+### Image Preprocessing
+
+Before invoking the agent, the worker scans the issue body for GitHub-hosted
+attachment images (URLs matching `github.com/user-attachments/assets/*`,
+`github.com/<owner>/<repo>/assets/*`, and
+`private-user-images.githubusercontent.com/*`). Matched images are downloaded to
+`.herd/tmp/images/` and the markdown URLs are replaced with local file paths so
+the agent can view them directly. External image URLs are left unchanged for the
+agent to handle. Downloading is best-effort -- if the HTTP client is unavailable
+or a download fails, the original URL is preserved.
+
 ### Concurrency
 
 Multiple workers run simultaneously on separate branches. Concurrency is bounded

--- a/src/content/docs/design/planner.md
+++ b/src/content/docs/design/planner.md
@@ -60,14 +60,13 @@ The interactive session is key to achieving these properties. The agent has full
 
 ## Worker Permissions and Manual Tasks
 
-Workers run as GitHub Actions with limited permissions. They can read/write repository contents, issues, and PRs. They **cannot**: create or modify GitHub Actions workflow files (`.github/workflows/`), manage secrets or repo settings, create repos, or interact with external services requiring authentication.
+Workers run as GitHub Actions with limited permissions. They can read/write repository contents, issues, and PRs. They **cannot**: manage secrets or repo settings, create repos, or interact with external services requiring authentication.
 
 The Planner evaluates each task against these boundaries. Any task requiring elevated permissions or external setup must be marked as **manual** (`"manual": true`). Manual tasks are tracked as GitHub Issues but not dispatched to workers — a human must complete and close them.
 
 **Manual tasks that grant permissions or set up external services must be in Tier 0.** These tasks unblock later tiers. If a worker needs a secret, API key, DNS record, or workflow permission to do its job, the manual task that provides it must complete first. Never place a setup task in a later tier than the tasks that depend on it.
 
 Common manual tasks:
-- Creating or modifying CI/CD workflow files
 - Configuring external services (DNS, CDN, cloud providers, APIs)
 - Setting up secrets, tokens, or environment variables
 - Creating repositories or managing GitHub settings

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -236,6 +236,8 @@ When you post a command, HerdOS reacts with 👀 to acknowledge it, executes the
 | `/herd review <focus area>` | Batch PR | Same as above, with extra review instructions |
 | `/herd fix <description>` | Batch PR | Creates a fix issue and dispatches a worker. The full PR comment thread is included in the fix issue so the worker has context of prior iterations. The reviewer automatically recognizes these fixes and will not flag them as acceptance criteria violations. |
 
+**Image support:** When you attach screenshots to `/herd fix` comments, workers automatically download GitHub-hosted attachment images and can view them directly. This is useful for UI bug fixes -- paste a screenshot of the problem or the desired result, and the worker will see it. Only GitHub attachment URLs are downloaded; external image URLs are left as-is for the agent to handle.
+
 ### Examples
 
 ```


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`fe9f786`](https://github.com/Herd-OS/herd/commit/fe9f78640fe4cd9a53c6e171d57ed6d868717911).