### PR TITLE
[herd] Use default mermaid dark theme (1 tasks)

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -134,21 +134,6 @@ const { title, currentSlug } = Astro.props;
       mermaid.initialize({
         startOnLoad: false,
         theme: 'dark',
-        themeVariables: {
-          primaryColor: '#ee7926',
-          primaryTextColor: '#fefefe',
-          primaryBorderColor: '#ee7926',
-          lineColor: '#ee7926',
-          secondaryColor: '#1e2d3d',
-          tertiaryColor: '#16202c',
-          mainBkg: '#1e2d3d',
-          nodeBorder: '#ee7926',
-          clusterBkg: '#16202c',
-          clusterBorder: '#ee7926',
-          titleColor: '#fefefe',
-          edgeLabelBackground: '#1e2d3d',
-          nodeTextColor: '#fefefe',
-        },
       });
 
       codeBlocks.forEach((codeEl) => {


### PR DESCRIPTION
## Summary

Batch **Use default mermaid dark theme** — 1 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #89 | Remove custom mermaid themeVariables from DocsLayout | 0 | done |

## Worker branches

- `herd/worker/89-remove-custom-mermaid-themevariables-from-docslayo`
