### PR TITLE
[herd] Use default mermaid dark theme (2 tasks)

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -134,11 +134,6 @@ const { title, currentSlug } = Astro.props;
       mermaid.initialize({
         startOnLoad: false,
         theme: 'dark',
-        flowchart: {
-          padding: 30,
-          wrappingWidth: 200,
-          useMaxWidth: true,
-        },
       });
 
       codeBlocks.forEach((codeEl) => {


### PR DESCRIPTION
## Summary

Batch **Use default mermaid dark theme** — 2 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #98 | Resolve rebase conflict: herd/batch/15-use-default-mermaid-dark-theme onto main | 0 | done |
| #89 | Remove custom mermaid themeVariables from DocsLayout | 0 | done |

## Worker branches

- `herd/worker/98-resolve-rebase-conflict-herdbatch15-use-default-me`
- `herd/worker/89-remove-custom-mermaid-themevariables-from-docslayo`
