### PR TITLE
Sync docs from herd@60226df

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -796,6 +796,21 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 
 ### Monitor Integration
 
+### Available Commands
+
+| Command | Context | Description |
+|---------|---------|-------------|
+| `/herd fix-ci` | Issue or PR | Check CI status and dispatch a fix worker if CI failed |
+| `/herd retry` | Issue | Re-dispatch the current failed issue's worker |
+| `/herd retry <N>` | Issue or PR | Re-dispatch failed issue #N's worker |
+| `/herd review` | PR | Trigger an agent review of the batch PR |
+| `/herd fix <description>` | PR | Create a fix issue from the description and dispatch a worker |
+| `/herd integrate` | Issue or PR | Run the full integrator cycle: consolidate → check CI → advance → review |
+| `/herd dispatch` | Issue | Dispatch the current issue (must be ready or blocked) |
+| `/herd dispatch <N>` | Issue or PR | Dispatch issue #N (must be ready or blocked) |
+
+### Monitor Integration
+
 The Monitor posts `/herd retry <N>` and `/herd fix-ci` comments instead of dispatching workflows directly. This ensures all command execution flows through the same handler, maintaining single responsibility.
 
 ### Failure Recovery


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`60226df`](https://github.com/Herd-OS/herd/commit/60226dffefc45f3306f11398264f288b590188e2).