### PR TITLE
Sync docs from herd@109a92d

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -29,6 +29,7 @@ workers:
   max_concurrent: 3              # max simultaneous worker Actions
   runner_label: "herd-worker"    # GitHub runner label for worker jobs
   timeout_minutes: 30            # max time per worker run
+  progress_interval_seconds: 30  # post progress updates to issue (0 = disabled)
 
 integrator:
   strategy: "squash"             # squash | rebase | merge

--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -144,6 +144,10 @@ The Integrator removes the `.herd/progress/` directory during consolidation
 do not appear in the final batch PR. For backward compatibility, legacy
 `WORKER_PROGRESS.md` files at the repo root are also removed.
 
+#### Live Progress Updates
+
+While the agent is working, the worker posts a progress comment on the issue and updates it periodically with the contents of the `.herd/progress/<issue-number>.md` file. This provides live visibility into what the agent has completed and what remains. The update interval is configurable via `workers.progress_interval_seconds` (default: 30 seconds, set to 0 to disable). When the worker finishes, the progress comment is updated one final time and kept on the issue for history.
+
 #### Retry Resume
 
 When a worker is re-dispatched for a previously timed-out task, it checks


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`109a92d`](https://github.com/Herd-OS/herd/commit/109a92dc3d615aaa383389858a097f788edbb313).