### PR TITLE
Sync docs from herd@4ba659a

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -807,11 +807,15 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 | `/herd fix-ci` | Issue or PR | Check CI status and dispatch a fix worker if CI failed |
 | `/herd retry` | Issue | Re-dispatch the current failed issue's worker |
 | `/herd retry <N>` | Issue or PR | Re-dispatch failed issue #N's worker |
-| `/herd review` | PR | Trigger an agent review of the batch PR |
+| `/herd review` | PR | Trigger an agent review of the PR |
 | `/herd fix <description>` | PR | Create a fix issue from the description and dispatch a worker |
 | `/herd integrate` | Issue or PR | Run the full integrator cycle: consolidate → check CI → advance → review |
 | `/herd dispatch` | Issue | Dispatch the current issue (must be ready or blocked) |
 | `/herd dispatch <N>` | Issue or PR | Dispatch issue #N (must be ready or blocked) |
+
+#### Non-Batch PR Reviews
+
+`/herd review` works on any PR, not just batch PRs. When used on a non-batch PR, it runs the same agent review and posts a severity-classified findings comment, but skips all batch-specific logic: no fix issues are created, no workers are dispatched, and no fix cycles are tracked. This is useful for getting an AI review on regular PRs without the full Herd orchestration.
 
 ### Monitor Integration
 

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -236,8 +236,8 @@ When you post a command, HerdOS reacts with 👀 to acknowledge it, executes the
 | `/herd fix-ci` | Batch PR | Checks CI status and dispatches fix workers if failing |
 | `/herd fix-ci <hint>` | Batch PR | Same as above, with context passed to the fix worker |
 | `/herd retry <issue-number>` | Any issue/PR | Re-dispatches a failed issue |
-| `/herd review` | Batch PR | Triggers agent review of the batch PR |
-| `/herd review <focus area>` | Batch PR | Same as above, with extra review instructions |
+| `/herd review` | Any PR | Triggers agent review of the PR. On batch PRs, findings create fix issues and dispatch workers; on non-batch PRs, only the severity-classified findings comment is posted. |
+| `/herd review <focus area>` | Any PR | Same as above, with extra review instructions |
 | `/herd fix <description>` | Batch PR | Creates a fix issue and dispatches a worker. The full PR comment thread is included in the fix issue so the worker has context of prior iterations. The reviewer automatically recognizes these fixes and will not flag them as acceptance criteria violations. |
 | `/herd integrate` | Any batch issue or PR | Manually triggers the integrator cycle (consolidate → check-ci → advance → review) for the batch. Useful for retrying after integrator failures. |
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`4ba659a`](https://github.com/Herd-OS/herd/commit/4ba659a558d5394318bdd76db642730b16bb48dc).