### PR TITLE
Sync docs from herd@b378232

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -462,9 +462,14 @@ reconciles during consolidation:
 1. **Auto-rebase.** If changes don't textually conflict, rebase succeeds.
 2. **Dispatch a conflict-resolution worker.** The Integrator creates a fix issue
    describing the conflict, the conflicting files, and the intent of each
-   worker. The resolver checks out the batch branch, reads both worker branches,
-   and produces a merged result. It pushes to its own worker branch and the
-   normal consolidate/advance flow handles it.
+   worker. The resolver runs as a normal worker on its own assigned worker
+   branch (`herd/worker/<fix-issue>-<slug>`). It runs `git fetch origin`,
+   `git merge origin/<conflicting-branch>`, resolves the conflict markers,
+   `git add`, and `git commit`. It does **not** `git push` and does **not**
+   `git checkout` the batch branch. The worker framework's normal
+   force-push of the worker branch carries the resolution commit, and the
+   Integrator's standard consolidate flow then merges the resolved worker
+   branch into the batch branch.
 3. **Notify the user.** Comment on the relevant issues with conflict details.
    The user resolves manually.
 
@@ -472,8 +477,11 @@ reconciles during consolidation:
 
 Main may advance while the batch executes. Before opening the PR, the Integrator
 rebases the batch branch onto latest main. If this conflicts, the same
-resolution strategies apply. The resolver force-pushes to the batch branch (the
-one acceptable force-push -- HerdOS owns the branch).
+resolution strategies apply: a resolver worker is dispatched and follows the
+same flow described above (stay on its own worker branch, `git merge` the
+default branch, commit, do not push). The worker framework pushes the worker
+branch, and the Integrator's consolidate flow merges it into the batch branch.
+No agent force-pushes the batch branch.
 
 The configured strategy (`on_conflict: notify | dispatch-resolver`) controls
 which path is taken. The resolver is capped at `max_conflict_resolution_attempts`
@@ -503,23 +511,32 @@ graph TD
     A["Batch A merges to main"] --> B["Batch B PR has conflicts"]
     B --> C["Monitor patrol detects Mergeable == false"]
     C --> D["Dispatch rebase conflict resolution worker"]
-    D --> E["Worker rebases batch branch onto main"]
-    E --> F["PR is mergeable again"]
+    D --> E["Worker stays on its own worker branch,<br>merges origin/main into it,<br>commits resolution"]
+    E --> F["Worker framework pushes worker branch;<br>Integrator consolidates it into batch branch"]
+    F --> G["PR is mergeable again"]
 ```
 
-### Improved Conflict Resolution Instructions
+### Conflict Resolution Instructions
 
 Conflict resolution issues (both worker-vs-worker and batch-vs-main) include
-explicit step-by-step git instructions to guide the resolver worker:
+explicit step-by-step git instructions to guide the resolver worker. Both
+flows use `git merge` against the resolver's own worker branch — the resolver
+never checks out the batch branch and never pushes:
 
-- **For merge conflicts:** `git fetch origin`, `git merge origin/main`, resolve
-  conflict markers, `git add`, `git commit`
-- **For rebase conflicts:** `git fetch origin`, `git rebase origin/main`, resolve
-  conflict markers, `git add`, `git rebase --continue`
-
-Workers are instructed to resolve actual conflict markers in-place rather than
-rewriting files from scratch, which preserves intentional changes from both
-sides.
+1. `git fetch origin`
+2. Stay on the assigned worker branch (`herd/worker/<fix-issue>-<slug>`); do
+   **not** run `git checkout` for the batch branch or default branch.
+3. `git merge origin/<conflicting-branch>` (the worker branch of the other
+   task for worker-vs-worker conflicts, or the default branch for
+   batch-vs-main conflicts).
+4. Resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in place —
+   do not rewrite files from scratch — to preserve intentional changes from
+   both sides.
+5. `git add <resolved files>` and `git commit` (accept the default merge
+   commit message).
+6. Do **not** `git push`. The worker framework pushes the worker branch
+   automatically; the Integrator's normal consolidate flow then merges the
+   resolved worker branch into the batch branch.
 
 ---
 
@@ -835,6 +852,10 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 | `herd review <pr-number>` | CLI | Local terminal | Open an interactive Claude Code session pre-loaded with the PR's diff, comments, and CI status. The agent acts as a reviewer/fixer assistant — you drive the conversation; it can read code, discuss findings, and make changes if you ask. It does NOT auto-dispatch workers or create issues. |
 
 Note on `herd review <pr-number>` vs `/herd review`: the CLI command opens an interactive local agent session for discussing and optionally fixing a PR — you stay in the loop and the agent only makes changes you approve. The slash command runs an automated agent review on the PR and posts findings as a comment. Use the CLI when you want a back-and-forth; use the slash command when you want a one-shot pre-screen.
+
+#### Draft-and-confirm /herd fix comments
+
+When the interactive `herd review <pr-number>` session reaches a concrete actionable conclusion — for example, "this finding is wrong, but we should still fix X" or "yes, let's add a test for Y" — the agent proactively drafts a `/herd fix` comment scoped to a single, focused task with specific files/functions and acceptance criteria. The agent shows the draft to the user and asks for approval; it never auto-posts. On approval, the agent posts the comment using `gh pr comment <pr-number> --repo <owner>/<repo> --body "..."`. Once posted, the herd workers (via the existing [`/herd fix` comment-command pipeline](#available-commands)) take over. If the conversation is purely informational, the agent does not propose a `/herd fix` comment.
 
 #### Non-Batch PR Reviews
 

--- a/src/content/docs/design/github-integration.md
+++ b/src/content/docs/design/github-integration.md
@@ -187,7 +187,7 @@ Multiple workers can complete near-simultaneously, triggering concurrent Integra
 
 **Concurrent consolidation:** If two merges into the batch branch race, the second push is rejected (non-fast-forward). The consolidate command handles this by pulling, retrying, and pushing again.
 
-**Double-dispatch prevention:** The `advance` command uses issue labels as an atomic guard -- it sets `in-progress` before dispatching, and skips any issue already `in-progress`. Label transitions via the GitHub API are atomic, so only one advance call can transition a given issue.
+**Double-dispatch prevention:** The `advance` command uses issue labels as an atomic guard -- it sets `in-progress` before dispatching, and skips any issue already `in-progress`. Label transitions via the GitHub API are atomic, so only one advance call can transition a given issue. As a belt-and-suspenders check, `dispatchReadyIssues` also lists `in_progress` and `queued` worker runs and skips any tier issue whose number already appears in an active run's inputs (labels are left untouched and the issue does not count against `dispatched`). This catches edge cases where labels and run state diverge — for example, if a prior dispatch's HTTP call failed after GitHub queued the run.
 
 **General rule:** All operations are idempotent. Labeling an already-labeled issue, dispatching an already-in-progress issue, and merging an already-merged branch are all detected and skipped.
 
@@ -313,7 +313,7 @@ The GitHub API client automatically retries requests that receive transient serv
 
 Network errors and client errors (4xx) are **not** retried — these indicate a problem with the request itself, not a transient server issue. If the request's context is cancelled during a backoff wait, the retry loop exits immediately.
 
-The retry transport wraps the underlying `http.RoundTripper`, so it applies to all GitHub API calls made through the client.
+The retry transport wraps the underlying `http.RoundTripper`, so it applies to all GitHub API calls made through the client, with one exception: `POST` requests targeting `/actions/workflows/{id}/dispatches` (workflow_dispatch) are sent as a single round trip with no retries. workflow_dispatch is not idempotent — GitHub may queue the run internally and then return a 5xx, so a retry would trigger a duplicate worker run. Callers that need to surface a transient dispatch failure must handle the 5xx themselves.
 
 ### Rate Limits and Audit
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`b378232`](https://github.com/Herd-OS/herd/commit/b3782328ef76b1239bf33bd22e7a74549567f9c3).