### PR TITLE
Sync docs from herd@6cc8db8

### DIFF
--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -109,6 +109,8 @@ To bypass all pre-flight checks:
 herd plan --skip-preflight "Add user authentication"
 ```
 
+`herd plan` also does a best-effort lookup of the latest published herd release and prints a one-line warning if you are behind. The check is bounded by a 3-second timeout and is silently skipped on network errors, dev builds, or pre-release tags — see [Installation → Upgrade notifications](installation.md#upgrade-notifications) for the full behavior.
+
 The planner automatically reads the repository structure, README, tech stack manifest, recent git history, and active batches to give the agent context about your project. The agent asks clarifying questions, then produces a decomposition with tasks, dependencies, and tier assignments. Before writing the plan file, the agent presents a high-level overview table (task number, title, tier, complexity, dependencies, manual flag). You can say "details" to see the full implementation plan, or "approve" to proceed immediately. You can approve at either step, request revisions, or reject — the agent only writes the plan file after explicit approval. Once approved and written, herd automatically creates issues and dispatches Tier 0 workers — no extra commands needed.
 
 To plan without auto-dispatching Tier 0:

--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -63,6 +63,20 @@ sudo cp bin/herd /usr/local/bin/
 
 ## Updating
 
+### Upgrade notifications
+
+`herd plan` and `herd init --check` perform a best-effort version check at start-up and print a one-line warning when a newer release is published. The check queries `https://api.github.com/repos/Herd-OS/herd/releases/latest` with a 3-second timeout; if it fails (no network, GitHub unreachable, non-200 response, etc.) nothing is printed and the command continues normally — the warning never blocks, and a missing warning is not a failure.
+
+Example warning:
+
+```
+⚠ A newer herd version is available: v0.6.0 (you are running v0.5.3). See https://github.com/Herd-OS/herd/releases/latest
+```
+
+When you see the warning, follow the [release page](https://github.com/Herd-OS/herd/releases/latest) and the steps below to upgrade.
+
+The check is skipped by design for development builds (`herd --version` reports `dev`) and for pre-release tags (anything containing `-`, e.g. `v0.5.3-rc.1`), so contributors and rc testers are not nagged about a "newer" stable release.
+
 ### Update the binary
 
 ```bash

--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -231,6 +231,8 @@ This makes it easy to wire into CI as a guard against forgetting to re-run `herd
 
 For day-to-day use, `herd plan` also prints a one-line warning when drift is detected, so you'll be nudged to re-run `herd init` without having to remember to check explicitly.
 
+Both `herd plan` and `herd init --check` additionally perform a best-effort lookup against `api.github.com` and warn when a newer herd release is published. The check is bounded by a 3-second timeout and never blocks; it is intentionally skipped for dev builds and pre-release tags. See [Installation → Upgrade notifications](installation.md#upgrade-notifications) for details.
+
 ## Private dependencies and extra secrets
 
 Worker runners often need to install private dependencies — Bundler from GitHub Packages, npm from a private registry, pip from a private index, cargo from a private Maven mirror, and so on. The package managers usually read credentials from environment variables (e.g. `BUNDLE_RUBYGEMS__PKG__GITHUB__COM`, `NPM_TOKEN`, `PIP_INDEX_URL`).


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`6cc8db8`](https://github.com/Herd-OS/herd/commit/6cc8db8b909431664305c9613fc8fb7295517808).