### PR TITLE
Sync docs from herd@fca78b5

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -850,6 +850,7 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 | `/herd dispatch` | Slash | Issue | Dispatch the current issue (must be ready or blocked) |
 | `/herd dispatch <N>` | Slash | Issue or PR | Dispatch issue #N (must be ready or blocked) |
 | `herd review <pr-number>` | CLI | Local terminal | Open an interactive Claude Code session pre-loaded with the PR's diff, comments, and CI status. The agent acts as a reviewer/fixer assistant — you drive the conversation; it can read code, discuss findings, and make changes if you ask. It does NOT auto-dispatch workers or create issues. |
+| `herd dashboard` | CLI | Local terminal | Live read-only TUI showing active workers, open batches, and recent failures. Refreshes on a `--refresh-seconds` timer (default 15, clamp 5–300). Keybinds: `q` quit, `r` refresh, ↑/↓ select batch, Enter to open the batch's PR or milestone. Worker rows render as OSC 8 hyperlinks where supported. Single-repo and read-only in v1. |
 
 Note on `herd review <pr-number>` vs `/herd review`: the CLI command opens an interactive local agent session for discussing and optionally fixing a PR — you stay in the loop and the agent only makes changes you approve. The slash command runs an automated agent review on the PR and posts findings as a comment. Use the CLI when you want a back-and-forth; use the slash command when you want a one-shot pre-screen.
 

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -109,6 +109,8 @@ To bypass all pre-flight checks:
 herd plan --skip-preflight "Add user authentication"
 ```
 
+`herd plan` also does a best-effort lookup of the latest published herd release and prints a one-line warning if you are behind. The check is bounded by a 3-second timeout and is silently skipped on network errors, dev builds, or pre-release tags — see [Installation → Upgrade notifications](installation.md#upgrade-notifications) for the full behavior.
+
 The planner automatically reads the repository structure, README, tech stack manifest, recent git history, and active batches to give the agent context about your project. The agent asks clarifying questions, then produces a decomposition with tasks, dependencies, and tier assignments. Before writing the plan file, the agent presents a high-level overview table (task number, title, tier, complexity, dependencies, manual flag). You can say "details" to see the full implementation plan, or "approve" to proceed immediately. You can approve at either step, request revisions, or reject — the agent only writes the plan file after explicit approval. Once approved and written, herd automatically creates issues and dispatches Tier 0 workers — no extra commands needed.
 
 To plan without auto-dispatching Tier 0:
@@ -165,6 +167,37 @@ herd status --json
 # Runner status
 herd status --runners
 ```
+
+### Live dashboard
+
+`herd dashboard` is a read-only terminal UI that shows active workers, open batches, and recent failures, refreshing on a timer.
+
+```bash
+herd dashboard
+```
+
+Override the refresh interval with `--refresh-seconds`:
+
+```bash
+herd dashboard --refresh-seconds 30
+```
+
+The interval is clamped to 5–300 seconds (default 15).
+
+Keybinds:
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit |
+| `r` | Manual refresh |
+| `↑` / `↓` | Select batch |
+| `Enter` | Open the selected batch's PR (or milestone, if no PR) in the browser |
+
+Worker rows in the top panel are emitted as OSC 8 hyperlinks pointing at the workflow run; supporting terminals render them as clickable links and others fall back to plain text.
+
+The dashboard is read-only and single-repo — cross-repo views and in-TUI actions are out of scope for v1.
+
+**See also:** `herd status` for one-shot or JSON output.
 
 ## Managing Batches
 

--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -63,6 +63,20 @@ sudo cp bin/herd /usr/local/bin/
 
 ## Updating
 
+### Upgrade notifications
+
+`herd plan` and `herd init --check` perform a best-effort version check at start-up and print a one-line warning when a newer release is published. The check queries `https://api.github.com/repos/Herd-OS/herd/releases/latest` with a 3-second timeout; if it fails (no network, GitHub unreachable, non-200 response, etc.) nothing is printed and the command continues normally — the warning never blocks, and a missing warning is not a failure.
+
+Example warning:
+
+```
+⚠ A newer herd version is available: v0.6.0 (you are running v0.5.3). See https://github.com/Herd-OS/herd/releases/latest
+```
+
+When you see the warning, follow the [release page](https://github.com/Herd-OS/herd/releases/latest) and the steps below to upgrade.
+
+The check is skipped by design for development builds (`herd --version` reports `dev`) and for pre-release tags (anything containing `-`, e.g. `v0.5.3-rc.1`), so contributors and rc testers are not nagged about a "newer" stable release.
+
 ### Update the binary
 
 ```bash

--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -231,6 +231,8 @@ This makes it easy to wire into CI as a guard against forgetting to re-run `herd
 
 For day-to-day use, `herd plan` also prints a one-line warning when drift is detected, so you'll be nudged to re-run `herd init` without having to remember to check explicitly.
 
+Both `herd plan` and `herd init --check` additionally perform a best-effort lookup against `api.github.com` and warn when a newer herd release is published. The check is bounded by a 3-second timeout and never blocks; it is intentionally skipped for dev builds and pre-release tags. See [Installation → Upgrade notifications](installation.md#upgrade-notifications) for details.
+
 ## Private dependencies and extra secrets
 
 Worker runners often need to install private dependencies — Bundler from GitHub Packages, npm from a private registry, pip from a private index, cargo from a private Maven mirror, and so on. The package managers usually read credentials from environment variables (e.g. `BUNDLE_RUBYGEMS__PKG__GITHUB__COM`, `NPM_TOKEN`, `PIP_INDEX_URL`).


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`fca78b5`](https://github.com/Herd-OS/herd/commit/fca78b56037f62eb07193d71c965c9e712772df3).