### PR TITLE
Sync docs from herd@380ba4a

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -35,7 +35,8 @@ workers:
 integrator:
   strategy: "squash"             # squash | rebase | merge
   on_conflict: "notify"          # notify | dispatch-resolver
-  max_conflict_resolution_attempts: 2
+  max_conflict_resolution_attempts: 2  # when exhausted, batch enters cascade-failed state
+                                       # (see design/execution.md#when-cascades-fail)
   require_ci: true
   review: true                   # agent reviews batch PRs before merge
   review_max_fix_cycles: 0       # max fix-and-re-review cycles (0 = unlimited)

--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -488,6 +488,12 @@ included as a `## Conversation History` section in the issue body. Each comment
 is formatted as `**@author:**` followed by the comment body, separated by `---`.
 This gives the fix worker full context of prior fix requests and review feedback.
 
+If the assembled body would exceed GitHub's 65,536-char limit, herd truncates
+it at the last clean boundary, appends a visible marker pointing at follow-up
+comments, and posts the remainder as one or more "Part N of M" comments on the
+same issue. The same handling applies to Review fix-issues, CI fix-issues, and
+conflict-resolution issues — see [github-integration.md → Body Size Limit](github-integration.md#body-size-limit).
+
 `/herd fix` also detects conflict-related keywords in the description (e.g.,
 "merge conflict", "rebase conflict", "conflict with main"). When detected, the
 handler automatically appends explicit git merge/rebase instructions to the fix
@@ -515,6 +521,41 @@ generating dozens of fix workers in one pass.
 | true | true | Agent is gatekeeper. Approves + CI pass = auto-merge. Issues block merge and trigger fix workers. |
 | false | true | No agent review. PR auto-merges as soon as CI passes. |
 | false | false | No agent review. Human reviews the batch PR directly. |
+
+### Stable disagreement
+
+When the reviewer keeps flagging the same findings cycle after cycle and a fix
+worker keeps responding with "no change needed" (after reading the issue and
+verifying the code), HerdOS detects the loop and pauses automatic review.
+
+**Detection.** Each fix worker that exits in the no-op path posts a structured
+`**Worker #N — no-op verdict**` comment on the batch PR with finding-by-finding
+reasoning. On the next review cycle, the Integrator passes those verdicts to
+the reviewer as authoritative context **and** compares the new findings against
+them. If the reviewer flags a finding that substantially matches a verdict
+(same first-100-character substring heuristic used for [fix-issue dedup](#review-fix-issue-dedup)),
+the Integrator halts the cycle.
+
+**Halt behavior.** When stable disagreement is detected, the Integrator:
+
+- Does **not** create a new fix issue.
+- Does **not** dispatch a fix worker.
+- Adds the `herd/stable-disagreement` label to the batch PR.
+- Posts a comment on the PR listing the re-flagged findings, the worker
+  verdicts, and the resolution options.
+
+While the `herd/stable-disagreement` label is present, automatic review is
+suspended. Manual `/herd review` and `/herd integrate` slash commands still
+execute — they bypass the label.
+
+**Recovery.** The user has three options:
+
+1. **The workers were right** — post `/herd fix` with explicit acceptance
+   criteria that close out the findings, or `/herd integrate` to merge as-is.
+2. **The reviewer was right** — post `/herd fix` with concrete `file:line`
+   evidence that contradicts the worker verdicts.
+3. **Resume automatic review** — remove the `herd/stable-disagreement` label
+   and post `/herd integrate`.
 
 ---
 
@@ -553,7 +594,8 @@ No agent force-pushes the batch branch.
 
 The configured strategy (`on_conflict: notify | dispatch-resolver`) controls
 which path is taken. The resolver is capped at `max_conflict_resolution_attempts`
-(default 2); after that, it falls back to notify regardless of config.
+(default 2); when that budget is exhausted, the batch enters cascade-failed
+state — see [When cascades fail](#when-cascades-fail).
 
 ### Monitor-Detected Batch-vs-Main Conflicts
 
@@ -605,6 +647,63 @@ never checks out the batch branch and never pushes:
 6. Do **not** `git push`. The worker framework pushes the worker branch
    automatically; the Integrator's normal consolidate flow then merges the
    resolved worker branch into the batch branch.
+
+### When cascades fail
+
+When a conflict-resolution worker itself produces a merge conflict, the
+integrator creates a follow-up conflict-resolution issue to resolve it.
+This can chain: an original failing worker → a first resolver → a second
+resolver, and so on. The chain is bounded by `integrator.max_conflict_resolution_attempts`
+(default: 2). When this budget is exhausted, the batch enters **cascade-failed**
+state.
+
+#### What triggers cascade-failed state
+
+The integrator reaches the cap when counting `conflict_resolution: true`
+issues in the milestone. On the next exhaustion event it:
+
+1. Relabels the current failing issue `herd/status:failed`.
+2. Adds the `herd/cascade-failed` label to the batch PR.
+3. Posts a detailed comment on the batch PR listing the full cascade
+   chain (e.g., `#641 → #643 → #644 (failed)`) and recovery steps.
+4. CC's everyone in `monitor.notify_users`.
+
+#### Label semantics
+
+The `herd/cascade-failed` label is **set automatically** by the
+integrator and **removed manually** by a human. While the label is
+present on a batch PR, Herd refuses to create any new
+conflict-resolution issues for that batch — every code path that would
+otherwise dispatch a conflict resolver (`handleConflictResolution`,
+`handleRebaseConflictResolution`, `DispatchRebaseConflictWorker`)
+short-circuits with a 'paused' comment.
+
+#### How to recover manually
+
+The batch PR comment lists three options in priority order:
+
+1. **Inspect** the failing worker branch:
+   ```
+   git fetch origin && git checkout <worker-branch>
+   ```
+2. **Rebase and resolve** locally, force-push the worker branch, then
+   post `/herd integrate` on the batch PR to resume consolidation.
+3. **Or close** the original failing issue if the work is no longer
+   needed, then post `/herd integrate` to advance past it.
+
+Once the underlying problem is handled, remove the `herd/cascade-failed`
+label from the batch PR. The next `/herd integrate` (or workflow_run
+trigger) will resume conflict resolution normally.
+
+#### Why we intentionally stop retrying
+
+Left unbounded, a single deep merge conflict can spawn an unbounded
+chain of conflict-resolution issues, each producing an orphan worker
+branch (e.g., `#641 → #643 → #644 → #645 → ...`). Each retry costs
+tokens and produces noise; once two automated attempts have failed, the
+remaining options require human judgment. The circuit breaker preserves
+the batch's invariants while making the failure loud and the recovery
+path explicit.
 
 ---
 
@@ -864,7 +963,8 @@ graph TD
     A["Worker A and Worker B<br>complete in the same tier"] --> B["Worker A merged into<br>batch branch successfully"]
     B --> C["Worker B conflicts with<br>Worker A's changes"]
     C --> D["Option A: Dispatch conflict-resolution worker<br>(on_conflict: dispatch-resolver,<br>capped at max_conflict_resolution_attempts)"]
-    C --> E["Option B: Notify user<br>(on_conflict: notify,<br>or after resolver cap reached)"]
+    C --> E["Option B: Notify user<br>(on_conflict: notify)"]
+    D --> F["Resolver cap reached?<br>Batch enters cascade-failed state<br>(see §6: When cascades fail)"]
 ```
 
 ### Recovering from a Stuck Tier
@@ -943,10 +1043,12 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 | `/herd integrate` | Slash | Issue or PR | Run the full integrator cycle: consolidate → check CI → advance → review |
 | `/herd dispatch` | Slash | Issue | Dispatch the current issue (must be ready or blocked) |
 | `/herd dispatch <N>` | Slash | Issue or PR | Dispatch issue #N (must be ready or blocked) |
-| `herd review <pr-number>` | CLI | Local terminal | Open an interactive Claude Code session pre-loaded with the PR's diff, comments, and CI status. The agent acts as a reviewer/fixer assistant — you drive the conversation; it can read code, discuss findings, and make changes if you ask. It does NOT auto-dispatch workers or create issues. |
+| `herd review <pr-number>` | CLI | Local terminal | Open an interactive Claude Code session pre-loaded with the PR's diff, comments, and CI status. The agent acts as a reviewer assistant — you drive the conversation; it can read code and discuss findings, and it drafts `/herd fix` comments for any actionable changes (it never edits files locally). It does NOT auto-dispatch workers or create issues. |
 | `herd dashboard` | CLI | Local terminal | Live read-only TUI showing active workers, open batches, and recent failures. Refreshes on a `--refresh-seconds` timer (default 15, clamp 5–300). Keybinds: `q` quit, `r` refresh, ↑/↓ select batch, Enter to open the batch's PR or milestone. Worker rows render as OSC 8 hyperlinks where supported. Single-repo and read-only in v1. |
 
-Note on `herd review <pr-number>` vs `/herd review`: the CLI command opens an interactive local agent session for discussing and optionally fixing a PR — you stay in the loop and the agent only makes changes you approve. The slash command runs an automated agent review on the PR and posts findings as a comment. Use the CLI when you want a back-and-forth; use the slash command when you want a one-shot pre-screen.
+Note on `herd review <pr-number>` vs `/herd review`: the CLI command opens an interactive local agent session for discussing a PR — the session is read-only on the working tree, and the only way it enacts changes is by drafting a `/herd fix` comment that you approve and post via `gh pr comment`; herd's batch workers then handle the actual edits. The slash command runs an automated agent review on the PR and posts findings as a comment. Use the CLI when you want a back-and-forth; use the slash command when you want a one-shot pre-screen.
+
+The review session is intentionally read-only on the working tree. Local edits during a review would create phantom commits that the integrator does not track and would conflict with any in-flight fix workers in the batch. All changes flow through `/herd fix` comments, which are dispatched to workers like any other batch task.
 
 #### Draft-and-confirm /herd fix comments
 
@@ -988,7 +1090,7 @@ Every automated feedback loop has a hard cap:
 |------|-----------|---------|----------|-------------|
 | Agent review / fix / re-review | review_max_fix_cycles | 0 (unlimited) | Comments on PR, waits for human | — |
 | Monitor re-dispatch | max_redispatch_attempts | 3 | Labels issue failed, stops | — |
-| Conflict resolution | max_conflict_resolution_attempts | 2 | Falls back to notify | `herd/rebase-pending` |
+| Conflict resolution | max_conflict_resolution_attempts | 2 | Batch enters [cascade-failed](#when-cascades-fail) state, blocks further resolvers | `herd/cascade-failed` |
 | CI failure fix cycles | ci_max_fix_cycles | 0 (unlimited) | Notifies user | `herd/ci-fix-pending` |
 
 ### Merge Strategy

--- a/src/content/docs/design/github-integration.md
+++ b/src/content/docs/design/github-integration.md
@@ -51,6 +51,14 @@ The body sections serve distinct purposes:
 
 Workers parse the front matter for metadata and pass the human-readable sections directly to the agent as the prompt. Manual issues (created by users) are also supported -- YAML front matter is optional, and without it the full body becomes the prompt.
 
+#### Body Size Limit
+
+GitHub caps issue and comment bodies at 65,536 characters. When herd creates an issue whose body would exceed a 65,000-char safety margin (e.g. a `/herd fix` issue with a long conversation history, a Review fix-issue with many findings, a CI fix-issue with a large log excerpt, or a conflict-resolution issue), the body is truncated at the last clean newline boundary and ends with the marker:
+
+> ⚠️ Body truncated to fit GitHub's 65536-char limit. See follow-up comment on this issue for the rest.
+
+The remainder is posted as one or more follow-up comments on the same issue. When the overflow spans multiple comments, each is prefixed with a `Part N of M (continued from issue body)` header so readers and the worker agent can reassemble them in order. Workers read the full picture from the issue body plus its comments, so no content is lost.
+
 ### Lifecycle State Machine
 
 ```
@@ -176,7 +184,7 @@ Several automated feedback loops exist. Each has explicit termination:
 | Tier advancement | DAG is finite | -- |
 | Agent review -> fix -> re-review | `review_max_fix_cycles` | Default: 3 |
 | Monitor re-dispatch | `max_redispatch_attempts` | Default: 3 |
-| Conflict resolution | `max_conflict_resolution_attempts` | Default: 2, then notify |
+| Conflict resolution | `max_conflict_resolution_attempts` | Default: 2, then [cascade-failed](execution.md#when-cascades-fail) |
 | CI failure after consolidation | `ci_max_fix_cycles` | Default: 2 |
 
 Additional safeguards: actions performed with `GITHUB_TOKEN` do not trigger further workflow runs (GitHub's built-in loop prevention), label filters restrict reactions to `herd/`-prefixed labels, guard clauses check for bot actors, and all state changes are idempotent.

--- a/src/content/docs/design/planner.md
+++ b/src/content/docs/design/planner.md
@@ -47,9 +47,22 @@ The user can approve at either step. Only after explicit approval does the agent
 
 The `herd plan` command gathers repository context, generates a unique plan ID, and launches the configured agent as a subprocess with a planning system prompt. HerdOS does not implement its own chat loop -- it delegates to whatever agent is configured, preserving the agent's native interactive experience.
 
-When the plan is ready, the agent first presents a high-level overview table (task number, title, tier, complexity, dependencies, manual flag). The user can say "details" to see the full implementation plan, or "approve" to proceed. If the user asks for details, the agent presents the complete plan in readable markdown. The user can request changes at either step — the agent incorporates feedback and re-presents until the user approves. Only after explicit approval does the agent write the structured plan to `.herd/plans/<plan-id>.json`. After the agent process exits, `herd` reads and parses the plan file, then creates issues and dispatches.
+When the plan is ready, the agent first presents a high-level overview table (task number, title, tier, complexity, dependencies, manual flag). The user can say "details" to see the full implementation plan, or "approve" to proceed. If the user asks for details, the agent presents the complete plan in readable markdown. The user can request changes at either step — the agent incorporates feedback and re-presents until the user approves. Only after explicit approval does the agent write the structured plan to `.herd/plans/<plan-id>.json`. After writing, the agent self-verifies the file (Step 4 of the planning prompt): it reads the JSON back, confirms it parses, checks the schema, and rewrites the file if any issue is found, before telling the user the plan is saved. After the agent process exits, `herd` reads and parses the plan file, then creates issues and dispatches.
 
 The agent writes to a file rather than stdout because agent stdout is mixed with conversation output, formatting, and UI elements. Parsing structured data from that stream would be fragile. A known file path is reliable and works identically across all agents.
+
+### Plan File Validation
+
+`herd` re-validates the plan when it loads the file (both in the normal exit path and when invoked with `--from-file`). The structural rules enforced by `validatePlan` are:
+
+- `batch_name` is non-empty.
+- At least one task is present.
+- Each task has a non-empty `title` and at least one `acceptance_criteria` entry.
+- Each `depends_on` index is within `[0, len(tasks))` and does not reference its own task.
+- `complexity` is one of `low`, `medium`, `high`, or empty.
+- `type` is one of `feature`, `bugfix`, or empty.
+
+On failure, the error identifies the offending task by index and title and names the field that failed (e.g. `task 3 ("Add login route"): depends_on[1]=7 is out of range [0,5)`). Because the plan file is preserved, the user can edit it and re-run `herd plan --from-file <path>` to recover without restarting the interactive session.
 
 ## Planning Quality Principles
 

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -133,6 +133,19 @@ If issue creation fails after planning, the plan file is preserved and the exact
 herd plan --from-file .herd/state/1234567890.json
 ```
 
+### Plan File Validation
+
+After writing the plan file, the agent self-verifies it (re-reads the file, confirms the JSON parses, and checks the schema before declaring success). When the file is loaded — either at the end of an interactive session or via `--from-file` — herd applies the same structural checks:
+
+- `batch_name` is non-empty.
+- At least one task is present.
+- Each task has a non-empty `title` and at least one `acceptance_criteria` entry.
+- Every `depends_on` index is in range and does not reference its own task.
+- `complexity` is one of `low`, `medium`, `high`, or empty.
+- `type` is one of `feature`, `bugfix`, or empty.
+
+If a check fails, herd fails fast and the error names the offending task index, title, and field — for example, `task 3 ("Add login route"): depends_on[1]=7 is out of range [0,5)`. Edit the plan JSON to fix the issue and re-run `herd plan --from-file <path>` to retry without restarting the agent session.
+
 ## Dispatching Workers
 
 After planning, Tier 0 tasks are dispatched automatically. To manually dispatch:
@@ -259,7 +272,7 @@ These are loaded automatically when the respective role runs.
 
 - **Worker failure** — The issue is labeled `herd/status:failed` and the Monitor is triggered immediately for fast escalation
 - **Tier stuck** — If any issue in a tier fails, the tier is stuck and the next tier won't be dispatched until the failure is resolved (manually or by the Monitor's auto-redispatch)
-- **Merge conflict** — When `on_conflict: dispatch-resolver`, the Integrator creates a conflict-resolution issue and dispatches a worker to resolve it. The number of attempts is limited by `max_conflict_resolution_attempts`. When `on_conflict: notify`, a comment is posted on the issue for manual resolution.
+- **Merge conflict** — When `on_conflict: dispatch-resolver`, the Integrator creates a conflict-resolution issue and dispatches a worker to resolve it. The number of attempts is limited by `max_conflict_resolution_attempts`; when that budget is exhausted, the batch enters cascade-failed state and the `herd/cascade-failed` label is applied to the batch PR — see [design/execution.md → When cascades fail](design/execution.md#when-cascades-fail). When `on_conflict: notify`, a comment is posted on the issue for manual resolution.
 - **Review safety valve** — If a single agent review finds more than 10 issues, fix workers are not created (to prevent runaway invocations). The PR is flagged for manual intervention.
 - **Unparseable review output** — If the review agent returns output that can't be parsed, the Integrator retries once after a 5-second delay within the same invocation. If both attempts fail, it posts a `⚠️ HerdOS Integrator — Agent review failed to produce valid output after 2 attempts` comment on the batch PR. Run `/herd review` on the PR to retry — the Integrator does not silently drop the review.
 
@@ -270,6 +283,14 @@ Some tasks in a batch may be labeled `herd/type:manual` — these require human 
 ### Re-triggering Review
 
 When a human submits a review on the batch PR, the Integrator's `re-review` job runs automatically, invoking the agent for a fresh review against the current diff. This allows you to push manual fixes and have the agent re-evaluate.
+
+## Interactive PR Review
+
+```bash
+herd review <pr-number>
+```
+
+Opens an interactive read-only review session pre-loaded with the PR's diff, comments, and CI status. The agent reads code and discusses findings with you, and drafts `/herd fix` comments for any actionable changes — it never edits files locally. When you approve a draft, the agent posts it via `gh pr comment`, and herd's batch workers handle the actual edit like any other fix task.
 
 ## Comment Commands
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`380ba4a`](https://github.com/Herd-OS/herd/commit/380ba4a61359e59ba1d0b19d8ac54c7774ae31ea).