### PR TITLE
Sync docs from herd@e8db42a

### DIFF
--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -20,7 +20,7 @@ This will:
 2. **Create `.herd/` directory** — with empty role instruction files (`planner.md`, `worker.md`, `integrator.md`) for customizing agent behavior per role
 3. **Create GitHub labels** — the `herd/*` label taxonomy used to track issue status and type
 4. **Install workflow files** — GitHub Actions workflows for workers, integrator, and monitor in `.github/workflows/`
-5. **Create runner files** — `Dockerfile.herd_runner_base`, `Dockerfile.herd_runner`, `entrypoint.herd.sh`, `docker-compose.herd.yml`, and `.env.herd.example` for self-hosted runner setup
+5. **Create runner files** — `Dockerfile.herd_runner` (which `FROM`s the published `ghcr.io/herd-os/herd-runner-base` base image), `docker-compose.herd.yml`, and `.env.herd.example` for self-hosted runner setup
 6. **Commit and open a PR** — creates a `herd/init-<version>` branch, commits all generated files, pushes, and opens a PR. Review and merge the PR to apply the changes.
 
 The installed version is recorded in `.herd/state/version` (gitignored) and used on subsequent runs to decide between install, update, and sync.

--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -164,7 +164,7 @@ The job:
 1. Checks out `main` with `fetch-depth: 0` (full history needed for the PR push).
 2. Downloads the just-built `herd-linux-amd64` artifact (avoiding a race against GitHub Release publication).
 3. Sets `HERD_VERSION=${{ github.ref_name }}` and runs `./herd init --skip-labels` against the herd repo itself.
-4. `herd init` regenerates the workflow files, runner Dockerfiles, entrypoint, `docker-compose.herd.yml`, and `.env.herd.example`. If anything changed, it commits to branch `herd/init-<tag>`, pushes, and opens a PR titled **`Update HerdOS to <tag>`**.
+4. `herd init` regenerates the workflow files, entrypoint, `docker-compose.herd.yml`, and `.env.herd.example` (the user-owned `Dockerfile.herd_runner` is created once and never overwritten). If anything changed, it commits to branch `herd/init-<tag>`, pushes, and opens a PR titled **`Update HerdOS to <tag>`**.
 5. If no herd-managed files changed in this release, no commit, no branch, and no PR are produced. The workflow logs:
 
    ```

--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -8,7 +8,7 @@ order: 4
 
 HerdOS workers run as GitHub Actions on self-hosted runners. Self-hosted runners are required because workers need an AI agent (Claude Code) installed, and because GitHub-hosted runners don't support `workflow_dispatch` chaining with custom tools.
 
-`herd init` generates all the files you need: `Dockerfile.herd_runner_base`, `Dockerfile.herd_runner`, `entrypoint.herd.sh`, `docker-compose.herd.yml`, and `.env.herd.example`.
+`herd init` generates all the files you need: `Dockerfile.herd_runner`, `docker-compose.herd.yml`, and `.env.herd.example`.
 
 ## Quick Setup
 
@@ -136,21 +136,26 @@ Configure at **org level** (recommended for multi-repo) or **repo level**:
 
 ## 5. What's in the Docker Image
 
-The runner image uses a two-layer Dockerfile system:
+The base image is **published** at `ghcr.io/herd-os/herd-runner-base` — a public, multi-arch (linux/amd64, linux/arm64) image that provides the GitHub Actions runner and base tools (Node 22, git, gh, curl, jq). `herd init` no longer generates a local `Dockerfile.herd_runner_base`; the base is pulled from GHCR instead. (If a `Dockerfile.herd_runner_base` is left over from an older init, re-running `herd init` removes it — see [Migrating from the local base image](#migrating-from-the-local-base-image).)
 
-- **`Dockerfile.herd_runner_base`** — herd-managed, always overwritten by `herd init`. Provides the GitHub Actions runner and base tools (curl, jq, git, gh, Node.js). Both the Herd CLI and Claude Code are downloaded at container startup by `entrypoint.herd.sh` to avoid Docker layer caching stale versions.
-- **`Dockerfile.herd_runner`** — user-owned, created once by `herd init`, never overwritten. Extends the base with `FROM herd-runner-base` and adds project-specific tools (Go, Python, Rust, linters, etc.).
+`herd init` generates a single user-owned Dockerfile:
 
-Edit `Dockerfile.herd_runner` to add your project's toolchain. For example, a Go project might add:
+- **`Dockerfile.herd_runner`** — user-owned, created once by `herd init`, never overwritten. Its first line is `FROM ghcr.io/herd-os/herd-runner-base:<herd-version>` (see [Runner images](#6-runner-images)). Add project-specific tools (languages, a database client, linters, etc.) below the `FROM` line.
+
+For example, to add a Postgres client on top of the base image:
 
 ```dockerfile
-FROM herd-runner-base
-RUN apt-get update && apt-get install -y golang-go && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/herd-os/herd-runner-base:v1.4.2
+USER root
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
+USER runner
 ```
 
-The **Herd CLI** is not baked into the image — it's downloaded at container startup by `entrypoint.herd.sh`. This ensures runners always use the latest version without rebuilding. Set `HERD_VERSION` in `.env` to pin a specific version.
+The base image runs as the non-root `runner` user, so switch to `root` to install packages and switch back when done.
 
-The `entrypoint.herd.sh` script handles runner lifecycle:
+The **Herd CLI** is not baked into the image — the entrypoint script that ships inside the published base image (`ghcr.io/herd-os/herd-runner-base`) downloads it at container startup. This ensures runners always use the latest version without rebuilding. Set `HERD_VERSION` in `.env` to pin a specific version.
+
+The base image's entrypoint script handles runner lifecycle:
 1. Downloads the herd binary (latest or pinned version)
 2. Removes stale config from previous runs (ephemeral runners leave `.runner` behind on restart)
 3. Registers with GitHub using a short-lived registration token
@@ -175,7 +180,43 @@ services:
 
 `herd init` automatically merges the override into `docker-compose.herd.yml`. The override file is never overwritten.
 
-## 6. Scaling
+## 6. Runner images
+
+The base image is a first-party runner image published to `ghcr.io/herd-os/` on every herd release. It is **public** (no `docker login` needed to pull) and **multi-arch** (linux/amd64, linux/arm64).
+
+| Image | Contents |
+|-------|----------|
+| `herd-runner-base` | OS + GitHub Actions runner + Node 22 + git/gh/curl/jq |
+
+`herd init` injects the base image into the `FROM` line of `Dockerfile.herd_runner` as `ghcr.io/herd-os/herd-runner-base:<herd-version>`. Add any additional tools or language toolchains by extending `Dockerfile.herd_runner` with `RUN apt-get install …` lines below the `FROM` line.
+
+### Version pinning
+
+The base image is pinned to the herd version that generated `Dockerfile.herd_runner` (e.g. `:v1.4.2`). The pin is refreshed when you re-run `herd init` from a newer herd binary, which rewrites the `FROM` tag. Dev builds (an empty or `dev` version) pin to `:latest`, because a `:dev` tag does not exist in GHCR and would fail to pull.
+
+### Building and publishing your runner image
+
+Once you've customized `Dockerfile.herd_runner`, you can build and publish the resulting image to GHCR under your own repository:
+
+```bash
+herd image build      # docker build -f Dockerfile.herd_runner -t ghcr.io/<owner>/<repo>-herd-runner:<tag> .
+docker login ghcr.io  # required before publishing
+herd image publish    # docker push ghcr.io/<owner>/<repo>-herd-runner:<tag>
+```
+
+The owner and repo are detected from your git remote and lower-cased; the tag defaults to the herd version (`latest` for dev builds) and can be overridden with `--tag`.
+
+This is also automated. `herd init` installs `.github/workflows/herd-publish-runner.yml`, which builds and pushes the multi-arch consumer image (`ghcr.io/<owner>/<repo>-herd-runner:latest`) on every push to `main` that touches `Dockerfile.herd_runner`, or on manual `workflow_dispatch`. The job is gated on the `HERD_ENABLED` variable being `true` and requires `packages: write` permission (the default `GITHUB_TOKEN` is used to authenticate to GHCR).
+
+### Migrating from the local base image
+
+Older versions of `herd init` generated a local two-layer build: a herd-managed `Dockerfile.herd_runner_base` plus a `Dockerfile.herd_runner` that did `FROM herd-runner-base`, with a separate base service in `docker-compose.herd.yml`. The base image is now published to GHCR, so:
+
+- Re-running `herd init` **removes** the obsolete `Dockerfile.herd_runner_base` and drops the base service from `docker-compose.herd.yml` (the worker now builds directly from `Dockerfile.herd_runner`).
+- If you **customized** `Dockerfile.herd_runner`, update its `FROM` line from `FROM herd-runner-base` to `FROM ghcr.io/herd-os/herd-runner-base:<version>` (re-running `herd init` will not overwrite this user-owned file).
+- The base image is **public**, so no `docker login` is needed to pull it at build time.
+
+## 7. Scaling
 
 ### Docker Compose
 
@@ -198,7 +239,7 @@ docker compose -f docker-compose.herd.yml up -d --scale worker=5
 
 `workers.runner_label` in `.herdos.yml` must match the `RUNNER_LABELS` environment variable in `docker-compose.herd.yml`. Default is `herd-worker`. Use different labels to route heavy tasks to specific runners (e.g., `herd-gpu`).
 
-## 7. Cloud Runners
+## 8. Cloud Runners
 
 You can run on cloud VMs instead of Docker. Requirements:
 
@@ -210,9 +251,9 @@ You can run on cloud VMs instead of Docker. Requirements:
 
 See [GitHub's self-hosted runner docs](https://docs.github.com/en/actions/hosting-your-own-runners) for detailed setup.
 
-## 8. Checking for updates
+## 9. Checking for updates
 
-`herd init` lays down a set of managed files — workflow YAMLs in `.github/workflows/`, `Dockerfile.herd_runner_base`, `entrypoint.herd.sh`, `docker-compose.herd.yml`, and `.env.herd.example`. Newer versions of the `herd` binary may render different content for those files, so a repository that was initialized against an older version can drift from the current templates over time.
+`herd init` lays down a set of managed files — workflow YAMLs in `.github/workflows/` (including `herd-publish-runner.yml`), `docker-compose.herd.yml`, and `.env.herd.example`. Newer versions of the `herd` binary may render different content for those files, so a repository that was initialized against an older version can drift from the current templates over time.
 
 `herd init --check` (with `--dry-run` as an alias) re-renders every managed file, compares the result against what's on disk, and prints a per-file summary: `✓` for files that match and `✗ <path> (would change)` followed by up to 5 lines of diff preview for files that differ. After the per-file output, it prints a final line of the form `N files would be modified, M unchanged`. The command exits 0 when nothing would change and 1 when any drift is detected.
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`e8db42a`](https://github.com/Herd-OS/herd/commit/e8db42aae649c5c040f35efcec8ea4bea24fd242).