### PR TITLE
Sync docs from herd@434e001

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -20,10 +20,10 @@ platform:
   repo: "my-project"             # repo name — auto-detected from git remote
 
 agent:
-  provider: "claude"             # claude (codex, cursor, gemini, opencode coming soon)
+  provider: "claude"             # claude | opencode (codex, cursor, gemini coming soon)
   binary: ""                     # path to agent binary (auto-detect if empty)
   model: ""                      # model override (optional, agent-specific)
-  max_turns: 0                   # max agentic turns in headless mode (0 = agent default)
+  max_turns: 0                   # max agentic turns in headless mode (0 = agent default; ignored by opencode)
 
 workers:
   max_concurrent: 3              # max simultaneous worker Actions
@@ -57,6 +57,29 @@ pull_requests:
   auto_merge: false              # auto-merge batch PRs after review passes
   co_author_email: ""            # Co-authored-by email (set after installing the GitHub App)
 ```
+
+## Agent Providers
+
+`agent.provider` selects which AI coding agent the worker shells out to. Valid values are `claude` (Anthropic Claude Code, default) and `opencode` ([OpenCode](https://opencode.ai)).
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `agent.provider` | string | `claude` | `claude` or `opencode` |
+| `agent.binary` | string | `claude` for the `claude` provider, `opencode` for the `opencode` provider | Path to the agent CLI binary. Empty falls back to the provider default and resolves via `PATH`. |
+| `agent.model` | string | `""` (provider default) | Model override. For `opencode`, use the provider/model form, e.g. `anthropic/claude-sonnet-4` or `openai/gpt-5`. |
+| `agent.max_turns` | int | `0` (agent default) | Maximum agentic turns in headless mode. **Ignored by the `opencode` provider** — OpenCode's `run` subcommand has no max-turns flag. |
+
+### Example: OpenCode
+
+```yaml
+agent:
+  provider: "opencode"
+  binary: ""                       # defaults to "opencode"
+  model: "anthropic/claude-sonnet-4"
+  max_turns: 0                     # ignored by opencode
+```
+
+The runner environment must have an API key for whichever provider the model resolves to (e.g. `ANTHROPIC_API_KEY` for `anthropic/...` models, `OPENAI_API_KEY` for `openai/...` models). See [runners.md](runners.md#2-agent-authentication) for the authentication setup.
 
 ## Review Strictness
 

--- a/src/content/docs/design/roadmap.md
+++ b/src/content/docs/design/roadmap.md
@@ -23,7 +23,7 @@ A user can:
 
 - Single-repo only (no cross-repo batches)
 - GitHub only (Platform interface exists but only GitHub is implemented)
-- Claude Code only (Agent interface exists but only Claude Code is implemented)
+- Claude Code and OpenCode supported (Agent interface; Codex, Cursor, and Gemini CLI still planned)
 
 ## v2 -- GitHub App and Multi-Agent
 
@@ -36,7 +36,7 @@ A user can:
 
 ### Multi-Agent
 
-Additional agent implementations (Codex, Cursor, Gemini CLI, OpenCode). Users can choose their preferred agent.
+OpenCode is implemented — set `agent.provider: opencode` in `.herdos.yml` (see [configuration.md](../configuration.md#agent-providers)). Remaining agent implementations (Codex, Cursor, Gemini CLI) are still planned so users can choose their preferred agent.
 
 ## v3 -- Multi-Platform
 

--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -102,6 +102,8 @@ You can preview what would change first with `herd init --check`, which re-rende
 
 `herd init` creates a `herd/init-<version>` branch, commits the updated files, pushes, and opens a PR. Review and merge the PR to apply the changes. Configuration (`.herdos.yml`) and role instructions (`.herd/*.md`) are never overwritten.
 
+`Dockerfile.herd_runner` is also user-owned and not overwritten, but `herd init` will auto-migrate its `FROM` line if it still references the pre-GHCR local base — `FROM herd-runner-base[:tag]` is rewritten to `FROM ghcr.io/herd-os/herd-runner-base:<herd-version>` while everything else in the file is left byte-identical. So the per-project upgrade flow is: upgrade the binary → `herd init` → merge the PR → redeploy runner containers, with no manual Dockerfile edit required. See [Runner Setup → Migrating from the local base image](runners.md#migrating-from-the-local-base-image) for the full migration behavior.
+
 ### Update runner containers
 
 Runner containers automatically download the latest herd binary on startup. Just restart them:

--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -6,7 +6,7 @@ order: 4
 
 # Runner Setup
 
-HerdOS workers run as GitHub Actions on self-hosted runners. Self-hosted runners are required because workers need an AI agent (Claude Code) installed, and because GitHub-hosted runners don't support `workflow_dispatch` chaining with custom tools.
+HerdOS workers run as GitHub Actions on self-hosted runners. Self-hosted runners are required because workers need an AI agent (Claude Code or OpenCode) installed, and because GitHub-hosted runners don't support `workflow_dispatch` chaining with custom tools.
 
 `herd init` generates all the files you need: `Dockerfile.herd_runner`, `docker-compose.herd.yml`, and `.env.herd.example`.
 
@@ -66,9 +66,13 @@ The same token works for both. `HERD_GITHUB_TOKEN` is needed because GitHub's au
 
 ## 2. Agent Authentication
 
+Authentication depends on which `agent.provider` is configured in `.herdos.yml` (see [configuration.md](configuration.md#agent-providers)).
+
+### Claude provider (`agent.provider: claude`)
+
 Choose one:
 
-### Option 1: OAuth token (recommended)
+#### Option 1: OAuth token (recommended)
 
 Uses your Claude Pro/Max subscription — no per-token cost.
 
@@ -84,7 +88,7 @@ CLAUDE_CODE_OAUTH_TOKEN=your-token-here
 
 Also add as an org or repo secret named `CLAUDE_CODE_OAUTH_TOKEN`.
 
-### Option 2: API key
+#### Option 2: API key
 
 Pay-per-token via https://console.anthropic.com/.
 
@@ -94,6 +98,24 @@ ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 Also add as an org or repo secret named `ANTHROPIC_API_KEY`.
+
+### OpenCode provider (`agent.provider: opencode`)
+
+OpenCode authenticates against whichever LLM provider the configured `agent.model` resolves to. Set the matching provider API key in the runner environment:
+
+| `agent.model` prefix | Required env var |
+|----------------------|------------------|
+| `anthropic/...` (e.g. `anthropic/claude-sonnet-4`) | `ANTHROPIC_API_KEY` |
+| `openai/...` (e.g. `openai/gpt-5`) | `OPENAI_API_KEY` |
+
+Add the relevant key to `.env`:
+```
+ANTHROPIC_API_KEY=sk-ant-...
+# or
+OPENAI_API_KEY=sk-...
+```
+
+Also add it as an org or repo secret with the same name so the GitHub Actions worker workflow can surface it. OpenCode does not use `CLAUDE_CODE_OAUTH_TOKEN`.
 
 > `.env` is auto-gitignored by `herd init` — credentials won't be committed.
 
@@ -125,8 +147,9 @@ Configure at **org level** (recommended for multi-repo) or **repo level**:
 | Secret/Variable | Type | Required | Purpose |
 |----------------|------|----------|---------|
 | `HERD_GITHUB_TOKEN` | Secret | Yes | PAT for workflow dispatch, releases, cross-repo ops |
-| `CLAUDE_CODE_OAUTH_TOKEN` | Secret | One of these | Agent auth — Pro/Max subscription |
-| `ANTHROPIC_API_KEY` | Secret | One of these | Agent auth — pay-per-token |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Secret | Claude only — one of these | Claude provider auth — Pro/Max subscription |
+| `ANTHROPIC_API_KEY` | Secret | Claude or OpenCode (anthropic models) — one of these | Agent auth — pay-per-token Anthropic API key |
+| `OPENAI_API_KEY` | Secret | OpenCode with `openai/...` model | OpenCode provider auth for OpenAI models |
 | `HERD_ENABLED` | Variable | Yes | Activates workflows — set to `true` after runners are online |
 | `HERD_RUNNER_LABEL` | Variable | No | Override default runner label (default: `herd-worker`) |
 
@@ -157,10 +180,11 @@ The **Herd CLI** is not baked into the image — the entrypoint script that ship
 
 The base image's entrypoint script handles runner lifecycle:
 1. Downloads the herd binary (latest or pinned version)
-2. Removes stale config from previous runs (ephemeral runners leave `.runner` behind on restart)
-3. Registers with GitHub using a short-lived registration token
-4. Starts the runner in ephemeral mode (picks up one job, then deregisters)
-5. On SIGTERM/SIGINT, deregisters cleanly
+2. Installs both supported agent CLIs via npm at container startup: Claude Code (`@anthropic-ai/claude-code`) and OpenCode (`opencode-ai`). Both are present in every runner regardless of which `agent.provider` the repo selects, so switching providers does not require rebuilding the image.
+3. Removes stale config from previous runs (ephemeral runners leave `.runner` behind on restart)
+4. Registers with GitHub using a short-lived registration token
+5. Starts the runner in ephemeral mode (picks up one job, then deregisters)
+6. On SIGTERM/SIGINT, deregisters cleanly
 
 The `docker-compose.herd.yml` runs the worker service with `restart: always`, so after each job completes the container restarts and re-registers for the next job.
 
@@ -192,7 +216,7 @@ The base image is a first-party runner image published to `ghcr.io/herd-os/` on 
 
 ### Version pinning
 
-The base image is pinned to the herd version that generated `Dockerfile.herd_runner` (e.g. `:v1.4.2`). The pin is refreshed when you re-run `herd init` from a newer herd binary, which rewrites the `FROM` tag. Dev builds (an empty or `dev` version) pin to `:latest`, because a `:dev` tag does not exist in GHCR and would fail to pull.
+The base image is pinned to the herd version that generated `Dockerfile.herd_runner` (e.g. `:v1.4.2`). The pin is refreshed when you re-run `herd init` from a newer herd binary: if the existing `FROM` line still references the legacy local base (`FROM herd-runner-base[:tag]`), it is auto-migrated to the version-pinned `ghcr.io/herd-os/herd-runner-base:<herd-version>` reference (see [Migrating from the local base image](#migrating-from-the-local-base-image)). `FROM` lines that already point at `ghcr.io` or use a custom base are left untouched, so re-running `herd init` will not bump an already-published `ghcr.io` reference for you — refresh those by editing `Dockerfile.herd_runner` yourself. Dev builds (an empty or `dev` version) pin to `:latest`, because a `:dev` tag does not exist in GHCR and would fail to pull.
 
 ### Building and publishing your runner image
 
@@ -213,8 +237,17 @@ This is also automated. `herd init` installs `.github/workflows/herd-publish-run
 Older versions of `herd init` generated a local two-layer build: a herd-managed `Dockerfile.herd_runner_base` plus a `Dockerfile.herd_runner` that did `FROM herd-runner-base`, with a separate base service in `docker-compose.herd.yml`. The base image is now published to GHCR, so:
 
 - Re-running `herd init` **removes** the obsolete `Dockerfile.herd_runner_base` and drops the base service from `docker-compose.herd.yml` (the worker now builds directly from `Dockerfile.herd_runner`).
-- If you **customized** `Dockerfile.herd_runner`, update its `FROM` line from `FROM herd-runner-base` to `FROM ghcr.io/herd-os/herd-runner-base:<version>` (re-running `herd init` will not overwrite this user-owned file).
+- `herd init` **auto-migrates** the `FROM` line in an existing `Dockerfile.herd_runner`. If a `FROM` line references the legacy local base (`FROM herd-runner-base` or `FROM herd-runner-base:<tag>`), that single line is rewritten to `FROM ghcr.io/herd-os/herd-runner-base:<herd-version>` and the rest of the file is left byte-identical (your customizations below the `FROM` line are preserved). Any trailing tokens on the matched `FROM` line — a multi-stage `AS <stage>` alias or a trailing `# comment` — are kept. Note that the matched `FROM` line itself is normalized: leading whitespace is dropped and internal whitespace between the tokens collapses to single spaces. `FROM` lines that already point at `ghcr.io` or use a custom base are left untouched. On migration, `herd init` prints `Migrated Dockerfile.herd_runner FROM line to <base-image>`; otherwise it prints `Dockerfile.herd_runner already exists (not overwritten)`.
 - The base image is **public**, so no `docker login` is needed to pull it at build time.
+
+This means the per-project upgrade from the old local-base model collapses to:
+
+1. Upgrade the `herd` binary (`brew upgrade herd-os/tap/herd`, or replace the binary — see [installation.md](installation.md)).
+2. Re-run `herd init` in the repository — the legacy `FROM` line is rewritten automatically.
+3. Merge the PR that `herd init` opens.
+4. Redeploy the runner containers (`docker compose -f docker-compose.herd.yml up -d --build`).
+
+No manual edit of `Dockerfile.herd_runner` is required.
 
 ## 7. Scaling
 
@@ -244,10 +277,14 @@ docker compose -f docker-compose.herd.yml up -d --scale worker=5
 You can run on cloud VMs instead of Docker. Requirements:
 
 1. Install the [GitHub Actions runner](https://github.com/actions/runner)
-2. Install Claude Code: `npm install -g @anthropic-ai/claude-code`
+2. Install both agent CLIs (matches the Docker base image, so either `agent.provider` works):
+   - Claude Code: `npm install -g @anthropic-ai/claude-code`
+   - OpenCode: `npm install -g opencode-ai`
 3. Install Herd CLI: `go install github.com/herd-os/herd/cmd/herd@latest`
 4. Register the runner with the `herd-worker` label
-5. Set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` in the runner's environment
+5. Set the agent credentials in the runner's environment:
+   - For `agent.provider: claude` — `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`
+   - For `agent.provider: opencode` — the provider API key for the configured model (e.g. `ANTHROPIC_API_KEY` for `anthropic/...` models, `OPENAI_API_KEY` for `openai/...` models)
 
 See [GitHub's self-hosted runner docs](https://docs.github.com/en/actions/hosting-your-own-runners) for detailed setup.
 
@@ -310,10 +347,10 @@ See [configuration.md](configuration.md) for the full field reference.
 | Runner not picking up jobs | Label mismatch | Ensure `RUNNER_LABELS` matches `workers.runner_label` in `.herdos.yml` |
 | Runner exits after one job | Expected | Ephemeral mode — `docker-compose` restarts it automatically |
 | "Must not run with sudo" | Running as root | The Dockerfile creates a non-root `runner` user — don't override `USER` |
-| Agent not found | Not installed | Ensure Claude Code is in the Docker image (`npm install -g @anthropic-ai/claude-code`) |
+| Agent not found | Not installed | Ensure the configured agent CLI is in the Docker image — the base image installs both (`npm install -g @anthropic-ai/claude-code` and `npm install -g opencode-ai`) |
 | 403 on PR creation | Org setting | Enable "Allow GitHub Actions to create and approve pull requests" in org settings |
 | 403 on listing PRs | Missing permission | Ensure `pull-requests: write` is in workflow permissions |
 | Dispatch succeeds but no run appears | Missing secret | Add `HERD_GITHUB_TOKEN` as org/repo secret (see section 1) |
 | Token permission errors | Insufficient scope | Fine-grained: needs Administration read/write. Classic: needs `repo` scope |
 | Integrator crashes checking CI | Missing Statuses permission | Add **Statuses: Read** to fine-grained PAT, or set `require_ci: false` in `.herdos.yml` |
-| Auth errors in worker | Missing credentials | Verify `.env` has `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
+| Auth errors in worker | Missing credentials | Verify `.env` has the right key for the configured provider — Claude: `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`; OpenCode: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` matching `agent.model` |


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`434e001`](https://github.com/Herd-OS/herd/commit/434e0011d2d910269fe775f5145c9fb64893bfef).