### PR TITLE
Sync docs from herd@e69fa6d

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -901,6 +901,84 @@ Manual tasks participate fully in the DAG:
 - **Notifications** -- when `notify_users` is configured, the Planner @mentions
   those users on manual task issues for visibility
 
+### Manual-task findings forwarding
+
+Manual tasks often produce information that downstream automated tasks need —
+a chosen library version, an API key location, a configuration decision, the
+shape of a value the human pasted into a secret. Workers, however, read only
+their **own** issue body at execution time (`worker.Exec` calls `Issues().Get`
+on its assigned issue; it never fetches dependency issues or their comments).
+Planner-inlined dependency context is frozen at plan time, so findings that a
+human records *after* planning would otherwise never reach the worker. The
+Integrator closes this gap by forwarding those findings into the dependent
+issue's body at dispatch time.
+
+**When and what.** Just before `dispatchReadyIssues` dispatches an automated
+issue, for each of that issue's `depends_on` entries that is a manual task
+(label `herd/type:manual`) **and** complete (state `closed` or label
+`herd/status:done`), the Integrator extracts the manual task's findings and
+injects them into the dependent issue's body. Findings are simply:
+
+- The manual task's issue body (with YAML front matter stripped via
+  `issues.StripFrontMatter`), kept verbatim.
+- Every human-authored comment on the manual issue, in chronological order.
+  Comments whose author login ends in `[bot]` and comments whose trimmed
+  body matches a known herd automated-comment prefix (e.g. `👋 **Manual
+  task**`, `🔍 **HerdOS Agent Review**`, `📋 **Worker Progress**`) are
+  excluded — those are not human findings.
+
+There is no special syntax the human must use. Anything they write in the
+issue body or as a non-bot comment is treated as findings.
+
+**Injected block format.** The forwarded text is wrapped in herd-internal
+HTML-comment markers keyed to the source manual issue:
+
+```
+<!-- herd:injected-findings:<N> -->
+## Context from #<N> (manual task)
+
+<extracted body + comments>
+
+<!-- /herd:injected-findings:<N> -->
+```
+
+Humans never author these markers — they exist solely so the Integrator can
+recognise an already-injected block.
+
+**Idempotency.** Because injection is keyed by the source issue number, a
+re-dispatch (or a second pass over the same dependent issue) detects the
+existing `<!-- herd:injected-findings:<N> -->` marker and skips re-injecting.
+The dependent issue's body therefore contains each manual dep's findings at
+most once, regardless of retry count.
+
+**Scope: manual deps only.** Only `herd/type:manual` dependencies forward
+findings. An automated dependency's "output" is the code it commits to the
+batch branch, which the worker already gets by checking out that branch —
+there is nothing to forward. Scanning the dependency list for manual deps is
+therefore the only extra work the Integrator does at dispatch time.
+
+**Size caps.** Two limits apply:
+
+- **Per dependency:** extracted findings are capped at 8 KB
+  (`perDepFindingsCap` = 8192 bytes). Content beyond the cap is truncated at
+  a UTF-8 rune boundary and replaced with a notice pointing at the source
+  issue: `_...truncated; see #<N> for full findings._`.
+- **Per dependent body:** if injecting a block would push the dependent
+  issue's body over `issues.MaxIssueBodyChars` (65000, GitHub's
+  safety-margin limit — see
+  [github-integration.md → Body Size Limit](github-integration.md#body-size-limit)),
+  that single injection is skipped with a warning. Dispatch still proceeds
+  with whatever findings did fit, so an oversize manual dep never blocks the
+  worker.
+
+**Out of scope.** Findings are read at dispatch time only — edits a human
+makes to the manual issue *after* its findings have been injected into a
+dependent are not re-forwarded automatically (the keyed marker means a
+subsequent injection pass treats that source as already done). Findings are
+also unstructured: there is no schema, no typed fields, no machine-readable
+contract — only freeform markdown that the downstream worker reads as part
+of its prompt.
+
 ---
 
 ## 10. Agent Error Resilience

--- a/src/content/docs/design/glossary.md
+++ b/src/content/docs/design/glossary.md
@@ -37,6 +37,15 @@ A group of tasks within a batch that can execute in parallel. Tasks with no depe
 ### Agent Review
 An automated review step where the Integrator dispatches an agent to review the consolidated batch PR. The agent checks acceptance criteria, looks for bugs and security issues, and posts a review. If issues are found, the Integrator dispatches fix workers and re-reviews (up to a configured limit, then escalates to human).
 
+### Findings Forwarding (Injected Findings)
+The mechanism by which a closed/done manual task's findings — its issue body
+(minus YAML front matter) and human-authored comments — are injected into the
+body of each dependent automated issue at dispatch time, so the downstream
+worker (which reads only its own issue body) sees them. The injected block is
+keyed by source issue number via herd-internal `<!-- herd:injected-findings:<N> -->`
+markers, making injection idempotent across retries. See
+[execution.md → Manual-task findings forwarding](execution.md#manual-task-findings-forwarding).
+
 ## Label Namespace
 
 All HerdOS labels use the `herd/` prefix to avoid collisions with existing repo labels.

--- a/src/content/docs/design/planner.md
+++ b/src/content/docs/design/planner.md
@@ -89,6 +89,23 @@ Common manual tasks:
 - Setting up secrets, tokens, or environment variables
 - Creating repositories or managing GitHub settings
 
+### Recording Findings on Manual Tasks
+
+When a manual task produces information that downstream automated tasks need
+(a chosen library version, the location of a provisioned resource, a value),
+the human records that information directly in the issue — in the body or as
+comments — before closing it. No special syntax or marker is required;
+freeform markdown is treated as findings. The Integrator forwards those
+findings into each dependent issue's body automatically at dispatch time, so
+the downstream worker sees them without ever reading the manual issue.
+
+The Planner reflects this in two places: the manual task's notification
+comment instructs the human to record findings before closing, and each
+dependent task's `context_from_dependencies` notes that findings from the
+manual dep will be injected automatically. See
+[execution.md → Manual-task findings forwarding](execution.md#manual-task-findings-forwarding)
+for the injection mechanics, idempotency, and size caps.
+
 ## Self-Contained Issues
 
 **The Planner does the thinking, the Worker does the typing.**


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`e69fa6d`](https://github.com/Herd-OS/herd/commit/e69fa6db3764f858d706deee0ed1c811ff612795).