### PR TITLE
Sync docs from herd@fa49621

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -20,9 +20,10 @@ platform:
   repo: "my-project"             # repo name — auto-detected from git remote
 
 agent:
-  provider: "claude"             # claude | opencode (codex, cursor, gemini coming soon)
+  provider: "claude"             # claude | opencode | codex (cursor, gemini coming soon)
   binary: ""                     # path to agent binary (auto-detect if empty)
   model: ""                      # model override (optional, agent-specific)
+  codex_reasoning_effort: "medium" # minimal | low | medium | high (codex provider only)
   max_turns: 0                   # max agentic turns in headless mode (0 = agent default; ignored by opencode)
   exec: "local"                  # local | docker — where `herd plan` runs the agent (local default)
   exec_image: ""                 # override image for exec: docker (default ghcr.io/herd-os/herd-runner-base:<herd-version>)
@@ -62,13 +63,14 @@ pull_requests:
 
 ## Agent Providers
 
-`agent.provider` selects which AI coding agent the worker shells out to. Valid values are `claude` (Anthropic Claude Code, default) and `opencode` ([OpenCode](https://opencode.ai)).
+`agent.provider` selects which AI coding agent the worker shells out to. Valid values are `claude` (Anthropic Claude Code, default), `opencode` ([OpenCode](https://opencode.ai)), and `codex` (OpenAI Codex CLI, API-key auth).
 
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
-| `agent.provider` | string | `claude` | `claude` or `opencode` |
-| `agent.binary` | string | `claude` for the `claude` provider, `opencode` for the `opencode` provider | Path to the agent CLI binary. Empty falls back to the provider default and resolves via `PATH`. |
-| `agent.model` | string | `""` (provider default) | Model override. For `opencode`, use the provider/model form, e.g. `anthropic/claude-sonnet-4` or `openai/gpt-5`. |
+| `agent.provider` | string | `claude` | `claude`, `opencode`, or `codex` |
+| `agent.binary` | string | `claude` for the `claude` provider, `opencode` for the `opencode` provider, `codex` for the `codex` provider | Path to the agent CLI binary. Empty falls back to the provider default and resolves via `PATH`. |
+| `agent.model` | string | `""` (provider default) | Model override. For `opencode`, use the provider/model form, e.g. `anthropic/claude-sonnet-4` or `openai/gpt-5`. For `codex`, use a **bare** model ID, e.g. `gpt-5-codex` or `gpt-5.2` (see [Codex model IDs](#codex-model-ids)). |
+| `agent.codex_reasoning_effort` | string | `medium` | Reasoning effort for the `codex` provider only: `minimal`, `low`, `medium`, or `high`. See [Codex reasoning effort](#codex-reasoning-effort). |
 | `agent.max_turns` | int | `0` (agent default) | Maximum agentic turns in headless mode. **Ignored by the `opencode` provider** — OpenCode's `run` subcommand has no max-turns flag. |
 | `agent.exec` | string | `local` | `local` runs the agent on your machine (requires the agent CLI installed locally). `docker` runs `herd plan` inside `ghcr.io/herd-os/herd-runner-base`, which already carries all agent CLIs — no local agent install needed beyond Docker + the herd binary. See [Local vs Docker Agent Execution](#local-vs-docker-agent-execution). |
 | `agent.exec_image` | string | `ghcr.io/herd-os/herd-runner-base:<herd-version>` | Override the image used by `exec: docker`. Empty defaults to the version-pinned base image (falls back to `:latest` on dev builds). |
@@ -85,37 +87,36 @@ agent:
 
 The runner environment must have an API key for whichever provider the model resolves to — e.g. `ANTHROPIC_API_KEY` for `anthropic/...` models, `OPENAI_API_KEY` for `openai/...` models. See [runners.md](runners.md#2-agent-authentication) for the authentication setup.
 
-## Local vs Docker Agent Execution
-
-`agent.exec` controls where `herd plan` runs the coding agent. The default is `local`: the agent runs directly on your machine. Power users who already have the agent CLIs installed prefer this — there is no container overhead.
-
-Setting `agent.exec: docker` runs `herd plan` inside the published runner image (`ghcr.io/herd-os/herd-runner-base`). herd mounts your current repo at `/work` inside the container and runs the same agent toolchain the workers use, so you need zero local agent install beyond Docker + the herd binary.
+### Example: Codex
 
 ```yaml
 agent:
-  provider: "claude"
-  exec: "docker"                   # run `herd plan` inside the runner image
-  exec_image: ""                   # optional: override the default base image
+  provider: "codex"
+  binary: ""                       # defaults to "codex"
+  model: "gpt-5-codex"             # bare model ID, NOT openai/gpt-5
+  codex_reasoning_effort: "medium" # minimal | low | medium | high
 ```
 
-### Override precedence
+The Codex provider uses API-key auth: set `OPENAI_API_KEY` (herd maps it to `CODEX_API_KEY` at invocation time when `CODEX_API_KEY` is unset) or set `CODEX_API_KEY` directly. See [runners.md](runners.md#codex-provider-agentprovider-codex) for the authentication setup.
 
-For one-off runs you can override the configured value. Precedence, highest first:
+#### Codex model IDs
 
-```
---exec local|docker  (flag)  >  HERD_EXEC env  >  agent.exec config  >  local (default)
-```
+Unlike the `opencode` provider, the `codex` provider expects a **bare** model ID in `agent.model` — e.g. `gpt-5-codex`, `gpt-5.2`, or `gpt-5.1` — **not** a provider-prefixed form like `openai/gpt-5`. The bare ID is passed straight through to the Codex CLI via `codex exec --model <id>`.
 
-### Recursion guard
+The IDs referenced by the source fixtures — `gpt-5-codex`, `gpt-5.2`, `gpt-5.1`, and `gpt-5.1-codex-max` — are known-good. <!-- TODO(verify): the full accepted Codex model registry is not exhaustively documented here. Confirm a candidate ID by running `codex exec --model <candidate>` before relying on it. -->
 
-When herd runs inside the container it sets `HERD_INSIDE_CONTAINER=1` and forces `local` execution for that process. This means a mounted `.herdos.yml` that says `exec: docker` cannot cause infinite docker-in-docker recursion — the inner herd always runs the agent locally inside the container. A single warning is logged when the guard fires.
+#### Codex reasoning effort
 
-### Behavior under `exec: docker`
+`agent.codex_reasoning_effort` controls how much reasoning the Codex model applies. It applies to the `codex` provider only.
 
-- **First-run image pull**: the first run pulls the multi-minute base image (Docker caches it afterward). herd prints a one-line `Pulling …` hint before the pull so you know what is happening.
-- **File ownership**: herd runs the container with `--user $(id -u):$(id -g)`, so files the agent creates in your worktree are owned by you, not root.
-- **gh auth**: if `~/.config/gh` exists it is mounted read-only, so the in-container herd can call the GitHub API with your existing `gh` credentials.
-- **`$EDITOR` caveat**: if the agent shells out to `$EDITOR` (e.g. Claude Code for some prompts), that editor runs **inside** the container, which does not carry your host editor. Avoid editor-dependent flows under `exec: docker`, or use `exec: local` for those.
+| Value | Notes |
+|-------|-------|
+| `minimal` | Least reasoning. |
+| `low` | |
+| `medium` | **Default.** |
+| `high` | Most reasoning. |
+
+The configured value maps to `-c model_reasoning_effort=<value>` on every Codex invocation (`exec`, plan, and review). An invalid value is rejected by config validation.
 
 ## Local vs Docker Agent Execution
 

--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -119,6 +119,26 @@ OPENAI_API_KEY=sk-...
 
 Also add it as an org or repo secret with the same name so the GitHub Actions worker workflow can surface it. This API-key path does not use `CLAUDE_CODE_OAUTH_TOKEN`.
 
+### Codex provider (`agent.provider: codex`)
+
+The Codex provider shells out to the OpenAI Codex CLI and authenticates with an API key. There is no OAuth/subscription path — only API-key auth is supported.
+
+#### API key
+
+Codex itself reads `CODEX_API_KEY`. herd supports two ways to provide it:
+
+- **Set `OPENAI_API_KEY`** — herd auto-maps it to `CODEX_API_KEY` at invocation time **when `CODEX_API_KEY` is unset**. This is convenient if you already have `OPENAI_API_KEY` in the environment (e.g. shared with the `opencode` provider).
+- **Set `CODEX_API_KEY` directly** — an explicit `CODEX_API_KEY` always wins; it is never overwritten by the `OPENAI_API_KEY` mapping.
+
+Add the key to `.env`:
+```
+OPENAI_API_KEY=sk-...
+# or, to set it explicitly:
+CODEX_API_KEY=sk-...
+```
+
+Also add the same secret name as an org or repo secret so the GitHub Actions worker workflow can surface it. The worker workflow forwards **both** `OPENAI_API_KEY` and `CODEX_API_KEY`, so configure whichever one you use as a secret.
+
 > `.env` is auto-gitignored by `herd init` — credentials won't be committed.
 
 > `.env` is for Docker runners (container registration and agent auth). Org/repo secrets are for GitHub Actions workflows. If you use Docker runners, you need both.
@@ -151,7 +171,8 @@ Configure at **org level** (recommended for multi-repo) or **repo level**:
 | `HERD_GITHUB_TOKEN` | Secret | Yes | PAT for workflow dispatch, releases, cross-repo ops |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Secret | Claude provider (one of these) | Claude provider auth — Pro/Max subscription |
 | `ANTHROPIC_API_KEY` | Secret | Claude or OpenCode (anthropic models) — one of these | Agent auth — pay-per-token Anthropic API key |
-| `OPENAI_API_KEY` | Secret | OpenCode with `openai/...` model | OpenCode provider auth for OpenAI models |
+| `OPENAI_API_KEY` | Secret | OpenCode with `openai/...` model, or Codex | OpenCode provider auth for OpenAI models; for Codex, auto-mapped to `CODEX_API_KEY` when that is unset |
+| `CODEX_API_KEY` | Secret | Codex (optional — explicit alternative to `OPENAI_API_KEY`) | Codex provider auth; an explicit value always wins over the `OPENAI_API_KEY` mapping |
 | `HERD_ENABLED` | Variable | Yes | Activates workflows — set to `true` after runners are online |
 | `HERD_RUNNER_LABEL` | Variable | No | Override default runner label (default: `herd-worker`) |
 
@@ -287,6 +308,7 @@ You can run on cloud VMs instead of Docker. Requirements:
 5. Set the agent credentials in the runner's environment:
    - For `agent.provider: claude` — `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`
    - For `agent.provider: opencode` — the provider API key for the configured model (e.g. `ANTHROPIC_API_KEY` for `anthropic/...` models, `OPENAI_API_KEY` for `openai/...` models)
+   - For `agent.provider: codex` — `OPENAI_API_KEY` (auto-mapped to `CODEX_API_KEY` when unset) or `CODEX_API_KEY` directly
 
 See [GitHub's self-hosted runner docs](https://docs.github.com/en/actions/hosting-your-own-runners) for detailed setup.
 
@@ -355,4 +377,4 @@ See [configuration.md](configuration.md) for the full field reference.
 | Dispatch succeeds but no run appears | Missing secret | Add `HERD_GITHUB_TOKEN` as org/repo secret (see section 1) |
 | Token permission errors | Insufficient scope | Fine-grained: needs Administration read/write. Classic: needs `repo` scope |
 | Integrator crashes checking CI | Missing Statuses permission | Add **Statuses: Read** to fine-grained PAT, or set `require_ci: false` in `.herdos.yml` |
-| Auth errors in worker | Missing credentials | Verify `.env` has the right key for the configured provider — Claude: `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`; OpenCode: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` matching `agent.model` |
+| Auth errors in worker | Missing credentials | Verify `.env` has the right key for the configured provider — Claude: `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`; OpenCode: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` matching `agent.model`; Codex: `OPENAI_API_KEY` or `CODEX_API_KEY` |


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`fa49621`](https://github.com/Herd-OS/herd/commit/fa49621ed5ec545af875febaae6060e522da244a).