### PR TITLE
Sync docs from herd@498dcd6

### DIFF
--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -258,7 +258,7 @@ The refreshed `auth.json` in the `codex-auth` volume is the source of truth — 
 
 ##### Keepalive
 
-When `~/.codex/auth.json` is present in the `codex-auth` volume, the runner entrypoint spawns a `herd codex keepalive-loop` goroutine. It periodically triggers Codex's own refresh via a near-noop `codex exec`, keeping idle OAuth chains warm so they don't lapse between batches. The default cadence is **6 days** (a ~2-day buffer before Codex's ~8-day forced refresh) and is tunable via `HERD_CODEX_KEEPALIVE_INTERVAL`, a Go duration string (e.g. `144h`). Logs go to `/var/log/herd-codex-keepalive.log`. The keepalive is **not** spawned for API-key-only or Enterprise-only (`CODEX_ACCESS_TOKEN`) setups, which need no refresh.
+When `~/.codex/auth.json` is present in the `codex-auth` volume, the runner entrypoint spawns a `herd codex keepalive-loop` goroutine. It periodically triggers Codex's own refresh via a near-noop `codex exec`, keeping idle OAuth chains warm so they don't lapse between batches. The default cadence is **6 days** (a ~2-day buffer before Codex's ~8-day forced refresh) and is tunable via `HERD_CODEX_KEEPALIVE_INTERVAL`, a Go duration string (e.g. `144h`). Logs go to `/opt/herd/herd-codex-keepalive.log` (owned by the runner user; survives the `RUNNER_UID` remap). The keepalive is **not** spawned for API-key-only or Enterprise-only (`CODEX_ACCESS_TOKEN`) setups, which need no refresh.
 
 ##### OpenAI security warnings
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`498dcd6`](https://github.com/Herd-OS/herd/commit/498dcd6cc9b0d97b380cb7a129908eb0266db8ba).