### PR TITLE
Sync docs from herd@ab1fdc9

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -24,6 +24,7 @@ agent:
   binary: ""                     # path to agent binary (auto-detect if empty)
   model: ""                      # model override (optional, agent-specific)
   codex_reasoning_effort: "medium" # minimal | low | medium | high (codex provider only)
+  codex_sandbox: ""              # read-only | workspace-write | danger-full-access (codex only; empty = workspace-write)
   max_turns: 0                   # max agentic turns in headless mode (0 = agent default; ignored by opencode)
   exec: "local"                  # local | docker — where `herd plan` runs the agent (local default)
   exec_image: ""                 # override image for exec: docker (default ghcr.io/herd-os/herd-runner-base:<herd-version>)
@@ -71,6 +72,7 @@ pull_requests:
 | `agent.binary` | string | `claude` for the `claude` provider, `opencode` for the `opencode` provider, `codex` for the `codex` provider | Path to the agent CLI binary. Empty falls back to the provider default and resolves via `PATH`. |
 | `agent.model` | string | `""` (provider default) | Model override. For `opencode`, use the provider/model form, e.g. `anthropic/claude-sonnet-4` or `openai/gpt-5`. For `codex`, use a **bare** model ID, e.g. `gpt-5-codex` or `gpt-5.2` (see [Codex model IDs](#codex-model-ids)). |
 | `agent.codex_reasoning_effort` | string | `medium` | Reasoning effort for the `codex` provider only: `minimal`, `low`, `medium`, or `high`. See [Codex reasoning effort](#codex-reasoning-effort). |
+| `agent.codex_sandbox` | string | `""` (uses `workspace-write`) | Codex CLI sandbox policy: `read-only`, `workspace-write`, or `danger-full-access`. **Set to `danger-full-access` for workers running inside a container** — Codex's bubblewrap-based sandboxes fail at startup with "No permissions to create a new namespace" on most container hosts (TrueNAS SCALE Apps, default Docker setups without `kernel.unprivileged_userns_clone=1`). The container is the security boundary in that context. See [Codex sandbox](#codex-sandbox). |
 | `agent.max_turns` | int | `0` (agent default) | Maximum agentic turns in headless mode. **Ignored by the `opencode` provider** — OpenCode's `run` subcommand has no max-turns flag. |
 | `agent.exec` | string | `local` | `local` runs the agent on your machine (requires the agent CLI installed locally). `docker` runs `herd plan` inside `ghcr.io/herd-os/herd-runner-base`, which already carries all agent CLIs — no local agent install needed beyond Docker + the herd binary. See [Local vs Docker Agent Execution](#local-vs-docker-agent-execution). |
 | `agent.exec_image` | string | `ghcr.io/herd-os/herd-runner-base:<herd-version>` | Override the image used by `exec: docker`. Empty defaults to the version-pinned base image (falls back to `:latest` on dev builds). |
@@ -95,6 +97,7 @@ agent:
   binary: ""                       # defaults to "codex"
   model: "gpt-5-codex"             # bare model ID, NOT openai/gpt-5
   codex_reasoning_effort: "medium" # minimal | low | medium | high
+  codex_sandbox: "danger-full-access" # required for container-based workers
 ```
 
 The Codex provider uses API-key auth: set `OPENAI_API_KEY` (herd maps it to `CODEX_API_KEY` at invocation time when `CODEX_API_KEY` is unset) or set `CODEX_API_KEY` directly. See [runners.md](runners.md#codex-provider-agentprovider-codex) for the authentication setup.
@@ -117,6 +120,21 @@ The IDs referenced by the source fixtures — `gpt-5-codex`, `gpt-5.2`, `gpt-5.1
 | `high` | Most reasoning. |
 
 The configured value maps to `-c model_reasoning_effort=<value>` on every Codex invocation (`exec`, plan, and review). An invalid value is rejected by config validation.
+
+#### Codex sandbox
+
+`agent.codex_sandbox` selects the Codex CLI's sandbox policy. Maps to `--sandbox <value>` on every `codex exec` invocation. Applies to the `codex` provider only.
+
+| Value | Notes |
+|-------|-------|
+| `read-only` | Codex can read files but not modify them. Bubblewrap-based. |
+| `workspace-write` | **Codex CLI default.** Codex can write within the workspace; network blocked. Bubblewrap-based. |
+| `danger-full-access` | No bubblewrap layer. Codex runs commands and edits files with full process privileges (the outer container or host is the boundary). |
+| `""` (empty) | Falls back to `workspace-write`. |
+
+**For workers running inside a Docker container, set `danger-full-access`.** The bubblewrap-based modes need an unprivileged user namespace, which most container hosts (notably TrueNAS SCALE Apps, default Docker without `sysctl kernel.unprivileged_userns_clone=1`) do not grant — every Codex shell or file edit fails with `bwrap: No permissions to create a new namespace`, the agent produces zero work, and the worker can't make progress. The container is already the security boundary in worker contexts, so disabling Codex's inner sandbox there is the correct trade-off.
+
+For local `agent.exec: local` use, leave it empty unless you specifically know your host can't run bubblewrap.
 
 ## Local vs Docker Agent Execution
 

--- a/src/content/docs/runners.md
+++ b/src/content/docs/runners.md
@@ -258,7 +258,7 @@ The refreshed `auth.json` in the `codex-auth` volume is the source of truth — 
 
 ##### Keepalive
 
-When `~/.codex/auth.json` is present in the `codex-auth` volume, the runner entrypoint spawns a `herd codex keepalive-loop` goroutine. It periodically triggers Codex's own refresh via a near-noop `codex exec`, keeping idle OAuth chains warm so they don't lapse between batches. The default cadence is **6 days** (a ~2-day buffer before Codex's ~8-day forced refresh) and is tunable via `HERD_CODEX_KEEPALIVE_INTERVAL`, a Go duration string (e.g. `144h`). Logs go to `/var/log/herd-codex-keepalive.log`. The keepalive is **not** spawned for API-key-only or Enterprise-only (`CODEX_ACCESS_TOKEN`) setups, which need no refresh.
+When `~/.codex/auth.json` is present in the `codex-auth` volume, the runner entrypoint spawns a `herd codex keepalive-loop` goroutine. It periodically triggers Codex's own refresh via a near-noop `codex exec`, keeping idle OAuth chains warm so they don't lapse between batches. The default cadence is **6 days** (a ~2-day buffer before Codex's ~8-day forced refresh) and is tunable via `HERD_CODEX_KEEPALIVE_INTERVAL`, a Go duration string (e.g. `144h`). Logs go to `/opt/herd/herd-codex-keepalive.log` (owned by the runner user; survives the `RUNNER_UID` remap). The keepalive is **not** spawned for API-key-only or Enterprise-only (`CODEX_ACCESS_TOKEN`) setups, which need no refresh.
 
 ##### OpenAI security warnings
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`ab1fdc9`](https://github.com/Herd-OS/herd/commit/ab1fdc9706f08f97a632612feaf93d05b966474a).