### PR TITLE
Home page: reflect multi-provider, subscription auth, comment commands

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -97,53 +97,53 @@ import HerdDemo from '../components/HerdDemo.jsx';
   <section class="py-20 px-4">
     <div class="max-w-6xl mx-auto">
       <h2 class="text-3xl sm:text-4xl font-bold text-center mb-16">Built for the AI-native workflow</h2>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+      <div class="flex flex-wrap justify-center gap-6">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:zap" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Parallel Execution</h3>
           <p class="text-white/60 text-sm leading-relaxed">Multiple agents work simultaneously on isolated branches. No contention, no waiting — just throughput.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="simple-icons:github" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">GitHub-Native</h3>
           <p class="text-white/60 text-sm leading-relaxed">Built on Issues, Actions, and PRs. No custom infrastructure, no databases, no daemons to run.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:refresh-cw" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Self-Healing</h3>
           <p class="text-white/60 text-sm leading-relaxed">Crashed workers are detected and redispatched automatically with exponential backoff. No silent failures.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:git-merge" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Conflict Resolution</h3>
           <p class="text-white/60 text-sm leading-relaxed">When parallel agents touch overlapping code, merge conflicts are detected and resolved without human intervention.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:bot" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Agent Review</h3>
           <p class="text-white/60 text-sm leading-relaxed">An AI reviewer checks the consolidated PR for bugs, security issues, and style — before you ever see it.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:plug" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Multi-Provider</h3>
           <p class="text-white/60 text-sm leading-relaxed">Claude Code, OpenCode, and Codex are first-class today — pick by capability, billing model, or both. Mix providers per role: Claude for planning, Codex for workers. Gemini CLI and Cursor are on the roadmap.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:wallet" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Subscription-Friendly</h3>
           <p class="text-white/60 text-sm leading-relaxed">Drive Codex from your existing ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise) instead of paying per-token. HerdOS keeps the OAuth chain warm so workers stay logged in between batches — no manual re-auth, no token-expiry surprises.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:message-square" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Comment Commands</h3>
           <p class="text-white/60 text-sm leading-relaxed">Trigger fixes, retries, and reviews by commenting <code class="text-orange font-mono text-xs">/herd fix</code> on a PR — from your phone, the GitHub web UI, anywhere. No going back to the terminal mid-batch.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:shield-check" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">You stay in control</h3>
           <p class="text-white/60 text-sm leading-relaxed">Workers run autonomously, but nothing merges without your approval. You review the PR, you decide what ships.</p>
         </div>
-        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:cloud-off" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Zero Infrastructure</h3>
           <p class="text-white/60 text-sm leading-relaxed">No database to run, no daemon to keep alive, no local compute. HerdOS shuts down completely when it's not working. Your laptop battery thanks you.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -97,53 +97,43 @@ import HerdDemo from '../components/HerdDemo.jsx';
   <section class="py-20 px-4">
     <div class="max-w-6xl mx-auto">
       <h2 class="text-3xl sm:text-4xl font-bold text-center mb-16">Built for the AI-native workflow</h2>
-      <div class="flex flex-wrap justify-center gap-6">
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:zap" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Parallel Execution</h3>
           <p class="text-white/60 text-sm leading-relaxed">Multiple agents work simultaneously on isolated branches. No contention, no waiting — just throughput.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="simple-icons:github" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">GitHub-Native</h3>
           <p class="text-white/60 text-sm leading-relaxed">Built on Issues, Actions, and PRs. No custom infrastructure, no databases, no daemons to run.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:refresh-cw" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Self-Healing</h3>
           <p class="text-white/60 text-sm leading-relaxed">Crashed workers are detected and redispatched automatically with exponential backoff. No silent failures.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:git-merge" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Conflict Resolution</h3>
           <p class="text-white/60 text-sm leading-relaxed">When parallel agents touch overlapping code, merge conflicts are detected and resolved without human intervention.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:bot" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Agent Review</h3>
           <p class="text-white/60 text-sm leading-relaxed">An AI reviewer checks the consolidated PR for bugs, security issues, and style — before you ever see it.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:plug" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Multi-Provider</h3>
           <p class="text-white/60 text-sm leading-relaxed">Claude Code, OpenCode, and Codex are first-class today — pick by capability, billing model, or both. Mix providers per role: Claude for planning, Codex for workers. Gemini CLI and Cursor are on the roadmap.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
-          <div class="mb-4"><Icon name="lucide:wallet" class="size-8 text-orange" /></div>
-          <h3 class="text-lg font-bold mb-2">Subscription-Friendly</h3>
-          <p class="text-white/60 text-sm leading-relaxed">Drive Codex from your existing ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise) instead of paying per-token. HerdOS keeps the OAuth chain warm so workers stay logged in between batches — no manual re-auth, no token-expiry surprises.</p>
-        </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
-          <div class="mb-4"><Icon name="lucide:message-square" class="size-8 text-orange" /></div>
-          <h3 class="text-lg font-bold mb-2">Comment Commands</h3>
-          <p class="text-white/60 text-sm leading-relaxed">Trigger fixes, retries, and reviews by commenting <code class="text-orange font-mono text-xs">/herd fix</code> on a PR — from your phone, the GitHub web UI, anywhere. No going back to the terminal mid-batch.</p>
-        </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:shield-check" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">You stay in control</h3>
           <p class="text-white/60 text-sm leading-relaxed">Workers run autonomously, but nothing merges without your approval. You review the PR, you decide what ships.</p>
         </div>
-        <div class="w-full sm:w-[calc(50%_-_0.75rem)] lg:w-[calc(25%_-_1.125rem)] bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:cloud-off" class="size-8 text-orange" /></div>
           <h3 class="text-lg font-bold mb-2">Zero Infrastructure</h3>
           <p class="text-white/60 text-sm leading-relaxed">No database to run, no daemon to keep alive, no local compute. HerdOS shuts down completely when it's not working. Your laptop battery thanks you.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -125,8 +125,18 @@ import HerdDemo from '../components/HerdDemo.jsx';
         </div>
         <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:plug" class="size-8 text-orange" /></div>
-          <h3 class="text-lg font-bold mb-2">Agent-Agnostic</h3>
-          <p class="text-white/60 text-sm leading-relaxed">Claude Code is the first-class supported agent today. The architecture supports any agent that can read a task and produce code — Codex, Gemini CLI, and others are on the roadmap.</p>
+          <h3 class="text-lg font-bold mb-2">Multi-Provider</h3>
+          <p class="text-white/60 text-sm leading-relaxed">Claude Code, OpenCode, and Codex are first-class today — pick by capability, billing model, or both. Mix providers per role: Claude for planning, Codex for workers. Gemini CLI and Cursor are on the roadmap.</p>
+        </div>
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+          <div class="mb-4"><Icon name="lucide:wallet" class="size-8 text-orange" /></div>
+          <h3 class="text-lg font-bold mb-2">Subscription-Friendly</h3>
+          <p class="text-white/60 text-sm leading-relaxed">Drive Codex from your existing ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise) instead of paying per-token. HerdOS keeps the OAuth chain warm so workers stay logged in between batches — no manual re-auth, no token-expiry surprises.</p>
+        </div>
+        <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
+          <div class="mb-4"><Icon name="lucide:message-square" class="size-8 text-orange" /></div>
+          <h3 class="text-lg font-bold mb-2">Comment Commands</h3>
+          <p class="text-white/60 text-sm leading-relaxed">Trigger fixes, retries, and reviews by commenting <code class="text-orange font-mono text-xs">/herd fix</code> on a PR — from your phone, the GitHub web UI, anywhere. No going back to the terminal mid-batch.</p>
         </div>
         <div class="bg-navy-light rounded-xl p-6 border border-white/5 hover:border-orange/30 transition-colors">
           <div class="mb-4"><Icon name="lucide:shield-check" class="size-8 text-orange" /></div>
@@ -227,6 +237,9 @@ import HerdDemo from '../components/HerdDemo.jsx';
         <div><span class="text-white/40">$</span> <span class="text-white">herd plan <span class="text-orange">"Add user authentication"</span></span></div>
         <div><span class="text-white/40">$</span> <span class="text-white">herd status --watch</span> <span class="text-white/40"># watch workers execute in real-time</span></div>
       </div>
+      <p class="max-w-2xl mx-auto mt-3 text-xs text-white/40 text-center">
+        Also on AUR (<code class="text-white/60 font-mono">yay -S herd-bin</code>), pre-built binaries, or from source — <a href="/docs/installation" class="text-orange/80 hover:text-orange underline">see all install methods</a>.
+      </p>
       <div class="max-w-2xl mx-auto mt-6 bg-orange/10 border border-orange/30 rounded-xl p-4 text-sm text-white/70">
         <p><span class="text-orange font-semibold">Note:</span> HerdOS runs workers on self-hosted GitHub Actions runners. You'll need at least one runner set up before dispatching. <a href="/docs/runners" class="text-orange underline hover:text-orange-dark">See the runner setup guide →</a></p>
       </div>


### PR DESCRIPTION
## Summary

The home page hadn't been updated since Codex and OpenCode landed as first-class providers, since per-role agent config shipped (`agent.planner` / `agent.workers`), or since the ChatGPT subscription auth path went in. Five targeted edits to the features grid + quick start; no layout overhaul.

## Features grid changes

| Card | Before | After |
|---|---|---|
| **Multi-Provider** (was "Agent-Agnostic") | "Claude Code is the first-class supported agent today. ... Codex, Gemini CLI, and others are on the roadmap." | "Claude Code, OpenCode, and Codex are first-class today — pick by capability, billing model, or both. Mix providers per role: Claude for planning, Codex for workers. Gemini CLI and Cursor are on the roadmap." |
| **Subscription-Friendly** (new) | — | "Drive Codex from your existing ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise) instead of paying per-token. HerdOS keeps the OAuth chain warm so workers stay logged in between batches — no manual re-auth, no token-expiry surprises." |
| **Comment Commands** (new) | — | "Trigger fixes, retries, and reviews by commenting `/herd fix` on a PR — from your phone, the GitHub web UI, anywhere. No going back to the terminal mid-batch." |

Subscription-Friendly is deliberately scoped to **ChatGPT** tiers only. The Claude Pro/Max subscription auth path is being deprecated upstream (planned shutoff in about a week as of writing), so leading with "use your Claude or ChatGPT subscription" would age badly within a release cycle. The card focuses on the path we know will keep working.

Card count goes from 8 to 10; the 4-column grid wraps to a final row of 2 cards. Visual is consistent with existing card styling.

## Quick Start change

Added one small centered link under the command block, between the snippet and the existing self-hosted-runners callout:

> Also on AUR (`yay -S herd-bin`), pre-built binaries, or from source — [see all install methods](/docs/installation).

Subordinate styling (`text-xs text-white/40`) so it doesn't compete with the highlighted `brew install` line. Routes Arch users and binary-download users to the existing `installation.md`.

## What I left alone (worth knowing)

- The `HerdDemo` component is still 100% Claude-flavored in its scripted output. A provider-aware demo is a bigger redesign than a home-page audit; not in scope here.
- The Hero, "You're not building. You're babysitting." pain section, "What the system handles for you," "Who this is for," Use Cases, Gastown heritage paragraph, and the closing CTA are all still accurate.
- Existing feature cards (Parallel Execution, GitHub-Native, Self-Healing, Conflict Resolution, Agent Review, You stay in control, Zero Infrastructure) are unchanged.

## Test plan

- [x] No links broken (`/docs/installation` and `/docs/runners` both exist under `src/content/docs/`).
- [x] Card content + icons render with the existing `bg-navy-light` / `hover:border-orange/30` styling.
- [ ] `npm run dev` and eyeball the new cards in the features grid for visual consistency.
- [ ] Mobile breakpoint: confirm the 10-card grid wraps cleanly at `sm:grid-cols-2` (5 rows of 2) and `lg:grid-cols-4` (2 rows of 4 + 1 row of 2).