### PR TITLE
Sync docs from herd@e000414

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -244,6 +244,8 @@ If the agent returns unparseable output (e.g., the JSON cannot be decoded, or th
 
 When you see that comment, run `/herd review` (optionally with a focus area) on the batch PR to trigger a fresh review. The integrator does not silently drop the review or auto-approve the PR.
 
+Review retries and manual `/herd review` commands are serialized per batch PR by an application-level GitHub-backed review lock. If another review is already running, the duplicate trigger is skipped instead of launching another agent. Manual review still bypasses stable-disagreement suspension, but it respects the active-review lock. Existing active-fix guards still prevent duplicate fix cycles after review findings have already created fix issues.
+
 ## CI Fix Loop
 
 `integrator.require_ci` enables CI failure detection on the batch branch. `integrator.ci_max_fix_cycles` caps how many CI-failure fix cycles the Integrator will dispatch (0 = unlimited).

--- a/src/content/docs/design/github-integration.md
+++ b/src/content/docs/design/github-integration.md
@@ -201,11 +201,12 @@ Multiple workers can complete near-simultaneously, triggering concurrent Integra
 
 #### Workflow Concurrency Groups
 
-All integrator workflow jobs use GitHub Actions [concurrency groups](https://docs.github.com/en/actions/using-jobs/using-concurrency) to prevent parallel runs from racing. Without these, two workers completing close together (or a `/herd integrate` comment firing at the same time as a `workflow_run` trigger) can cause duplicate fix issues, duplicate worker dispatches, and duplicate review comments.
+All integrator workflow jobs use GitHub Actions [concurrency groups](https://docs.github.com/en/actions/using-jobs/using-concurrency) as defense-in-depth to reduce obvious overlap. Without these, two workers completing close together (or a `/herd integrate` comment firing at the same time as a `workflow_run` trigger) can cause duplicate fix issues, duplicate worker dispatches, and duplicate review attempts.
 
 | Job | Group Key | cancel-in-progress | Rationale |
 |-----|-----------|-------------------|----------|
 | `integrate` | `herd-integrate-{head_branch}` | false | Serializes all integrator runs. Workers are dispatched with `ref: defaultBranch`, so `head_branch` is typically `main` — this serializes across batches, which is acceptable since integrator runs are quick and touch shared state. |
+| `check-ci-workflow-completion` | `herd-integrate-{head_branch}` | false | Optional when `integrator.ci_workflows` is configured. Serializes CI workflow completion handling with other workflow-run Integrator work on the same batch branch. |
 | `check-ci-on-completion` | `herd-check-ci-{head_branch}` | true | Fires once per `check_run` completion on a batch branch. Idempotent — only the last run matters, so earlier runs are cancelled to save runner time. |
 | `advance-on-close` | `herd-advance-{milestone \|\| issue_number}` | false | Uses milestone number (= batch number) to serialize per-batch. Falls back to issue number for non-herd issues. |
 | `re-review` | `herd-re-review-{pr_number}` | false | Prevents concurrent reviews on the same PR. |
@@ -214,7 +215,25 @@ All integrator workflow jobs use GitHub Actions [concurrency groups](https://doc
 
 All groups use `cancel-in-progress: false` (except `check-ci-on-completion`) so that queued runs wait rather than being cancelled. Every integrator run should complete — we want serialization, not cancellation.
 
-**Cross-job limitation:** The `integrate` and `handle-comment` jobs cannot share a concurrency group because they use different event payloads (`workflow_run` vs `issue_comment`) with no common batch identifier extractable at the expression level. Both jobs are idempotent, so concurrent execution produces duplicate work at worst, not data corruption.
+**Cross-job limitation:** Workflow concurrency cannot express one shared review group across every trigger HerdOS supports. Different event payloads expose different identifiers (`workflow_run`, `check_run`, `issues`, `pull_request_review`, and `issue_comment`), and manual commands do not always have the same batch PR fields available at expression time. HerdOS therefore treats workflow concurrency as a secondary guard. The correctness guarantee for agent review comes from an application-level GitHub-backed lock on the batch PR.
+
+#### Agent Review Locking
+
+Batch PR reviews acquire an application-level GitHub-backed lock before the Integrator fetches context or starts the review agent. The lock is per PR, so only one Herd agent review may run for a batch PR at a time while independent batch PRs can still review concurrently. Workflow concurrency is defense-in-depth only; correctness comes from the app-level lock and GitHub's atomic ref-update behavior.
+
+Lock acquisition and release are compare-and-swap operations against opaque lock state stored in GitHub. If two runs attempt to acquire or release the lock concurrently, only the run whose view of the current state is still valid succeeds; the other run reloads the latest state and either retries or observes that another review already owns the lock. A release is scoped to the holder that acquired the lock, so stale holders cannot release a newer review's lock.
+
+Duplicate triggers do not launch another agent review. They log or comment:
+
+```
+Review already in progress for PR #N; skipping duplicate review trigger.
+```
+
+Stale locks expire conservatively after their recorded expiry window so a dead Actions job does not block future reviews forever. The implementation treats expiry as recovery from an abandoned review, not as permission for overlapping active reviews. Manual `/herd review` still bypasses stable-disagreement suspension, but it never bypasses the active-review lock.
+
+Pre-append-only lock branches from older HerdOS versions are migrated only when their old marker commit is recognizable as a Herd review lock and is stale according to its acquisition timestamp. Unknown or fresh legacy state fails closed rather than risking duplicate reviews.
+
+Hidden PR comments are not authoritative for locking. If diagnostic lock comments exist, HerdOS filters them out of review context and never uses them to decide whether a lock is active; the GitHub-backed lock state is authoritative.
 
 ## 4. Runners
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`e000414`](https://github.com/Herd-OS/herd/commit/e000414f070babe4ee729f0e616b4d1634fe54d3).