### PR TITLE
Sync docs from herd@39feb7e

### DIFF
--- a/src/content/docs/design/execution.md
+++ b/src/content/docs/design/execution.md
@@ -371,6 +371,14 @@ graph TD
 
 Opening the batch PR is idempotent: if concurrent advance-on-close triggers race, the second call detects the existing PR (via listing or by handling a 422 "already exists" error) and returns its number instead of failing.
 
+The generated batch PR body starts with a reviewer-facing `## Summary` section,
+then `Major changes:` bullets and `## Validation`, followed by the existing
+Herd operational sections: `## Tasks` and `## Worker branches`. PR creation
+remains deterministic and does not invoke an agent. New batches use the
+milestone description populated from the plan's top-level `pr_summary`; older
+batches without that metadata use fallback text derived from the milestone
+title, issue titles, and parsed acceptance criteria.
+
 Before opening the batch PR, the Integrator sanity-checks that the milestone's issue list returned by the GitHub API is complete (the count of fetched issues is at least `OpenIssues + ClosedIssues`). If the list is short — typically a transient partial API response — it logs `Warning: milestone #N has X expected issues (Y open + Z closed) but only K were returned by the API; skipping batch PR to avoid premature open` and skips PR creation; the PR opens on a subsequent advance once the API returns complete data. Likewise, if the issue triggering an advance is not found in any tier (another partial-response symptom), the Integrator logs `Warning: issue #N not found in any tier of milestone #M (possibly partial API response); skipping advance` and treats the trigger as a no-op rather than returning an error.
 
 ### Run-to-Milestone Resolution

--- a/src/content/docs/design/planner.md
+++ b/src/content/docs/design/planner.md
@@ -144,6 +144,7 @@ The good version continues with exact interface signatures, type definitions, th
 The agent produces a structured plan containing:
 
 - **Batch name** -- a short descriptive name for the overall unit of work, which becomes the GitHub Milestone title. If the chosen name collides with an existing milestone, the Planner appends a numeric suffix (`<name> (2)`, `<name> (3)`, ..., up to `<name> (10)`) and uses the first variant that does not exist. See [Milestone Name Conflicts](#milestone-name-conflicts) below.
+- **`pr_summary`** -- a concise reviewer-facing paragraph for the generated batch PR body. This is review context, not operational bookkeeping. Herd stores it in durable batch metadata via the GitHub Milestone description when creating the batch.
 - **Tasks** -- an ordered list where each task includes:
   - **Title** -- concise name for the task, becomes the GitHub Issue title.
   - **Description** -- what to build (the "what").

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -257,7 +257,7 @@ Once workers are dispatched, the system runs autonomously via GitHub Actions:
 
 6. **Monitor patrols** — A cron-triggered Action detects stale workers (in-progress with no active run), failed issues (auto-redispatches with exponential backoff), CI failures on batch PRs, and stuck PRs (open longer than `max_pr_age_hours`). It escalates to `notify_users` when retries are exhausted.
 
-7. **You review and merge** — The batch PR arrives with a summary table of all tasks and their tiers. If `pull_requests.auto_merge` is true and the agent review passed, it merges automatically. If you close the PR without merging, cleanup still runs: non-done issues are labelled `herd/status:cancelled`, the milestone is closed, and the branch is deleted.
+7. **You review and merge** — The batch PR arrives with a reviewer-facing summary, major changes, validation notes, and then the task/tier table. If `pull_requests.auto_merge` is true and the agent review passed, it merges automatically. If you close the PR without merging, cleanup still runs: non-done issues are labelled `herd/status:cancelled`, the milestone is closed, and the branch is deleted.
 
 ### Role Instruction Files
 


### PR DESCRIPTION
Automated sync of documentation from [Herd-OS/herd@`39feb7e`](https://github.com/Herd-OS/herd/commit/39feb7ed09a17696c85ca82ae85313b0f9dc4868).